### PR TITLE
Rename `amount_near` to `price`

### DIFF
--- a/contract/src/lib.rs
+++ b/contract/src/lib.rs
@@ -11,7 +11,6 @@ use near_sdk::{
 
 pub const TGAS: u64 = 1_000_000_000_000;
 pub const XCC_GAS: Gas = Gas(5 * TGAS); // cross contract gas
-pub const NEAR_TO_YACTO: u128 = 1_000_000_000_000_000_000_000_000;
 
 pub mod externals;
 pub use crate::externals::*;
@@ -334,7 +333,7 @@ mod tests {
     */
     use near_sdk::serde_json::json;
     use near_sdk::test_utils::{accounts, VMContextBuilder};
-    use near_sdk::testing_env;
+    use near_sdk::{testing_env, ONE_NEAR};
 
     use super::*;
 
@@ -365,7 +364,7 @@ mod tests {
         let borrower: AccountId = accounts(3).into();
         let nft_address: AccountId = accounts(4).into();
         let expiration = 1000;
-        let price = 1 * NEAR_TO_YACTO;
+        let price = 1 * ONE_NEAR;
 
         contract.nft_on_approve(
             token_id.clone(),

--- a/frontend/src/AcceptBorrowingPage.jsx
+++ b/frontend/src/AcceptBorrowingPage.jsx
@@ -29,7 +29,7 @@ export default function AcceptBorrowingPage() {
   }, []);
 
   let onSubmit = () => {
-    console.log(acceptLease(leaseId, borrowing[1].amount_near));
+    console.log(acceptLease(leaseId, borrowing[1].price));
   };
 
   return borrowing ? (
@@ -128,7 +128,7 @@ export default function AcceptBorrowingPage() {
                     </label>
                     <div className="mt-1 sm:col-span-2 sm:mt-0">
                       {window.nearApi.utils.format.formatNearAmount(
-                        BigInt(borrowing[1].amount_near).toString()
+                        BigInt(borrowing[1].price).toString()
                       )}
                     </div>
                   </div>

--- a/frontend/src/NftContract.js
+++ b/frontend/src/NftContract.js
@@ -40,7 +40,7 @@ export async function newLease(
     token_id: tokenId,
     borrower: borrower,
     expiration: expiration,
-    amount_near: amountYacto.toString(),
+    price: amountYacto.toString(),
   });
   let tokens = await contract.nft_approve({
     args: {


### PR DESCRIPTION
`amount_near` is a misleading name, it's actually in the unit of yacto Near.

Also change to use U128 as the argument data type, so that the near sdk will handle both integer or string a parameter automatically.