### PR TITLE
Request and store payout when activating lease

### DIFF
--- a/contract/src/externals.rs
+++ b/contract/src/externals.rs
@@ -1,16 +1,15 @@
-use near_contract_standards::non_fungible_token::TokenId;
-use near_sdk::{ext_contract, AccountId};
+use crate::*;
 
-// // Interface of this contract, for call backs - place holder
-// #[ext_contract(ext_self)]
-// pub trait Callbacks {
-// }
+/// Interface of this contract
+#[ext_contract(ext_self)]
+trait ExtSelf {
+    fn activate_lease(&mut self, lease_id: LeaseId) -> Promise;
+}
 
-// NFT interface, for cross-contract calls
-// For details, refer to NEP-171
+/// NFT interface, for cross-contract calls
+/// For details, refer to NEP-171
 #[ext_contract(ext_nft)]
 pub trait Nft {
-    // cross-contract call
     fn nft_transfer(
         &mut self,
         receiver_id: AccountId,
@@ -19,12 +18,15 @@ pub trait Nft {
         memo: Option<String>,
     );
 
-    fn nft_transfer_call(
+    /// Payout Support
+    /// See https://nomicon.io/Standards/Tokens/NonFungibleToken/Payout
+    fn nft_transfer_payout(
         &mut self,
-        receiver_id: AccountId,   // account to receive the token
-        token_id: TokenId,        // nft token to be sent
-        approval_id: Option<u64>, // approval ID, in case transfer is sent from ppl with valid approval
+        receiver_id: AccountId,
+        token_id: String,
+        approval_id: Option<u64>,
         memo: Option<String>,
-        msg: String, // info needed by the receiving contract to handl the transfer.
+        balance: U128,
+        max_len_payout: Option<u32>,
     );
 }

--- a/contract/src/lib.rs
+++ b/contract/src/lib.rs
@@ -1,21 +1,40 @@
+use std::collections::HashMap;
+
 use near_contract_standards::non_fungible_token::TokenId;
 
 use near_sdk::borsh::{self, BorshDeserialize, BorshSerialize};
-use near_sdk::bs58;
 use near_sdk::collections::UnorderedMap;
 use near_sdk::json_types::U128;
 use near_sdk::serde::{Deserialize, Serialize};
+use near_sdk::{bs58, ext_contract, promise_result_as_success, serde_json};
 use near_sdk::{
     env, log, near_bindgen, AccountId, Balance, BorshStorageKey, Gas, PanicOnDefault, Promise,
 };
 
-pub const TGAS: u64 = 1_000_000_000_000;
-pub const XCC_GAS: Gas = Gas(5 * TGAS); // cross contract gas
-
 pub mod externals;
 pub use crate::externals::*;
 
-type LeaseId = String;
+// Copied from Paras market contract. Will need to be fine-tuned.
+pub const TGAS: u64 = 1_000_000_000_000;
+pub const XCC_GAS: Gas = Gas(5 * TGAS); // cross contract gas
+pub const GAS_FOR_NFT_TRANSFER: Gas = Gas(20_000_000_000_000);
+pub const BASE_GAS: Gas = Gas(5 * TGAS);
+pub const GAS_FOR_ROYALTIES: Gas = Gas(BASE_GAS.0 * 10u64);
+
+pub type LeaseId = String;
+pub type PayoutHashMap = HashMap<AccountId, U128>;
+
+/// A mapping of NEAR accounts to the amount each should be paid out, in
+/// the event of a token-sale. The payout mapping MUST be shorter than the
+/// maximum length specified by the financial contract obtaining this
+/// payout data. Any mapping of length 10 or less MUST be accepted by
+/// financial contracts, so 10 is a safe upper limit.
+/// See more: https://nomicon.io/Standards/Tokens/NonFungibleToken/Payout#reference-implementation
+#[derive(BorshDeserialize, BorshSerialize, Serialize, Deserialize, PartialEq, Debug)]
+#[serde(crate = "near_sdk::serde")]
+pub struct Payout {
+    pub payout: PayoutHashMap,
+}
 
 #[derive(BorshDeserialize, BorshSerialize, Serialize, PartialEq, Debug)]
 #[serde(crate = "near_sdk::serde")]
@@ -52,8 +71,9 @@ pub struct LeaseCondition {
     borrower: AccountId,      // Borrower of the NFT
     approval_id: u64,         // Approval from owner to lease
     expiration: u64,          // TODO: duration
-    price: u128,              // proposed lease cost
-    state: LeaseState,        // current lease state
+    price: u128,              // Proposed lease price
+    payout: Option<Payout>,   // Payout info (e.g. for Royalty split)
+    state: LeaseState,        // Current lease state
 }
 
 #[near_bindgen]
@@ -101,13 +121,40 @@ impl Contract {
         ext_nft::ext(lease_condition.contract_addr.clone())
             .with_static_gas(Gas(10 * TGAS))
             .with_attached_deposit(1)
-            .nft_transfer_call(
-                env::current_account_id(),                    // receiver_id
-                lease_condition.token_id.clone(),             // token_id
-                None,                                         // approval_id
-                None,                                         // memo
-                format!(r#"{{"lease_id":"{}"}}"#, &lease_id), // message should include the leaseID
+            .nft_transfer_payout(
+                env::current_account_id(),                 // receiver_id
+                lease_condition.token_id.clone(),          // token_id
+                Some(lease_condition.approval_id.clone()), // approval_id
+                None,                                      // memo
+                U128::from(lease_condition.price),         // price
+                Some(50u32),                               // max length payout
+            )
+            .then(
+                ext_self::ext(env::current_account_id())
+                    .with_attached_deposit(0)
+                    .with_static_gas(GAS_FOR_ROYALTIES)
+                    .activate_lease(lease_id),
             );
+    }
+
+    #[private]
+    pub fn activate_lease(&mut self, lease_id: LeaseId) {
+        log!("Activating lease ({})", &lease_id);
+
+        // TODO: avoid re-fetch lease condition
+        let lease_condition: LeaseCondition = self.lease_map.get(&lease_id).unwrap();
+
+        let optional_payout: Option<Payout> = promise_result_as_success().and_then(|value| {
+            // TODO(libo): validate the payout
+            serde_json::from_slice::<Payout>(&value).ok()
+        });
+
+        let new_lease_condition = LeaseCondition {
+            state: LeaseState::Active,
+            payout: optional_payout,
+            ..lease_condition
+        };
+        self.lease_map.insert(&lease_id, &new_lease_condition);
     }
 
     pub fn leases_by_owner(&self, account_id: AccountId) -> Vec<(String, LeaseCondition)> {
@@ -216,60 +263,6 @@ impl Contract {
     }
 }
 
-// TODO: move this callback function trait to a separate file e.g. nft_callbacks.rs
-/**
-    Train that will handle the cross contract call from NFT contract. When nft.nft_transfer_call is called,
-    it will fire a cross contract call to this_contract.nft_on_transfer(). For deails, refer to NEP-171.
-*/
-trait NonFungibleTokenTransferReceiver {
-    fn nft_on_transfer(
-        &mut self,
-        sender_id: AccountId, // account that initiated the nft.nft_transfer_call(). e.g. current contract
-        previous_owner_id: AccountId, // old owner of the token
-        token_id: TokenId,    // NFT token id
-        msg: String,
-    ) -> bool;
-}
-
-#[near_bindgen]
-impl NonFungibleTokenTransferReceiver for Contract {
-    #[payable]
-    fn nft_on_transfer(
-        &mut self,
-        sender_id: AccountId,
-        previous_owner_id: AccountId,
-        token_id: TokenId,
-        msg: String,
-    ) -> bool {
-        // This function can only be called by initial transfer sender, which should be the current lease contract.
-        assert_eq!(
-            sender_id,
-            env::current_account_id(),
-            "sender_id does NOT match current contract id!"
-        );
-
-        let nft_on_transfer_json: NftOnTransferJson =
-            near_sdk::serde_json::from_str(&msg).expect("Not valid msg for nft_on_transfer");
-
-        log!(
-            "Updating lease condition for lease_id: {}",
-            &nft_on_transfer_json.lease_id
-        );
-
-        let lease_condition: LeaseCondition =
-            self.lease_map.get(&nft_on_transfer_json.lease_id).unwrap();
-        let new_lease_condition = LeaseCondition {
-            state: LeaseState::Active,
-            ..lease_condition
-        };
-        self.lease_map
-            .insert(&nft_on_transfer_json.lease_id, &new_lease_condition);
-
-        // all updates are completed. Return false, so that nft_resolve_transfer() from nft contract will not revert this transfer
-        return false;
-    }
-}
-
 // TODO: move nft callback function to separate file e.g. nft_callbacks.rs
 /**
     trait that will be used as the callback from the NFT contract. When nft_approve is
@@ -311,6 +304,7 @@ impl NonFungibleTokenApprovalsReceiver for Contract {
             borrower: lease_json.borrower,
             expiration: lease_json.expiration,
             price: lease_json.price.0,
+            payout: None,
             state: LeaseState::Pending,
         };
 
@@ -334,7 +328,7 @@ mod tests {
     use super::*;
     use near_sdk::serde_json::json;
     use near_sdk::test_utils::{accounts, VMContextBuilder};
-    use near_sdk::{testing_env, ONE_NEAR};
+    use near_sdk::{testing_env, PromiseResult, RuntimeFeesConfig, VMConfig, ONE_NEAR};
 
     #[test]
     fn test_new() {
@@ -428,6 +422,36 @@ mod tests {
             .build());
 
         contract.lending_accept(key);
+    }
+
+    #[test]
+    fn test_activate_lease_success() {
+        let mut contract = Contract::new(accounts(1).into());
+        let lease_condition = create_lease_condition_default();
+        let key = "test_key".to_string();
+        contract.lease_map.insert(&key, &lease_condition);
+
+        let payout = Payout {
+            payout: HashMap::from([(accounts(2).into(), U128::from(1))]),
+        };
+
+        testing_env!(
+            get_context_builder(lease_condition.borrower.clone())
+                .attached_deposit(lease_condition.price)
+                .build(),
+            VMConfig::test(),
+            RuntimeFeesConfig::test(),
+            HashMap::default(),
+            vec![PromiseResult::Successful(
+                serde_json::to_vec(&payout).unwrap()
+            )],
+        );
+
+        contract.activate_lease(key.clone());
+
+        let lease_condition_result = contract.lease_map.get(&key).unwrap();
+        assert_eq!(lease_condition_result.payout, Some(payout));
+        assert_eq!(lease_condition_result.state, LeaseState::Active);
     }
 
     #[test]
@@ -684,6 +708,7 @@ mod tests {
             approval_id,
             expiration.clone(),
             price,
+            None,
             LeaseState::Pending,
         )
     }
@@ -697,6 +722,7 @@ mod tests {
         approval_id: u64,
         expiration: u64,
         price: u128,
+        payout: Option<Payout>,
         state: LeaseState,
     ) -> LeaseCondition {
         LeaseCondition {
@@ -707,6 +733,7 @@ mod tests {
             approval_id,
             expiration,
             price,
+            payout,
             state,
         }
     }

--- a/contract/src/lib.rs
+++ b/contract/src/lib.rs
@@ -15,6 +15,7 @@ pub mod externals;
 pub use crate::externals::*;
 
 // Copied from Paras market contract. Will need to be fine-tuned.
+// https://github.com/ParasHQ/paras-marketplace-contract/blob/2dcb9e8b3bc8b9d4135d0f96f0255cd53116a6b4/paras-marketplace-contract/src/lib.rs#L17
 pub const TGAS: u64 = 1_000_000_000_000;
 pub const XCC_GAS: Gas = Gas(5 * TGAS); // cross contract gas
 pub const GAS_FOR_NFT_TRANSFER: Gas = Gas(20_000_000_000_000);

--- a/contract/src/lib.rs
+++ b/contract/src/lib.rs
@@ -436,7 +436,9 @@ mod tests {
         };
 
         testing_env!(
-            get_context_builder(lease_condition.borrower.clone())
+            VMContextBuilder::new()
+                .current_account_id(accounts(0))
+                .predecessor_account_id(lease_condition.borrower.clone())
                 .attached_deposit(lease_condition.price)
                 .build(),
             VMConfig::test(),


### PR DESCRIPTION
As the first step of implementing the payout (i.e. Royalty) functionality, we store the payout info given by the NFT contract when transfering the NFT to our contract. This info will be later used to split the rent payment to all relavant parties when the NFT got claimed back.

It also replaced the nft_transfer callback with a private contract function called `activate_lease`. This is a better way to handle multiple async operation (i.e. promises) in a transcational way.