### PR TITLE
[NR-36] Add indices for look up & unit tests

### DIFF
--- a/contract/src/externals.rs
+++ b/contract/src/externals.rs
@@ -4,6 +4,7 @@ use crate::*;
 #[ext_contract(ext_self)]
 trait ExtSelf {
     fn activate_lease(&mut self, lease_id: LeaseId) -> Promise;
+    fn resolve_claim_back(&mut self, lease_id: LeaseId) -> Promise;
 }
 
 /// NFT interface, for cross-contract calls

--- a/contract/src/lib.rs
+++ b/contract/src/lib.rs
@@ -22,6 +22,7 @@ pub const XCC_GAS: Gas = Gas(5 * TGAS); // cross contract gas
 pub const GAS_FOR_NFT_TRANSFER: Gas = Gas(20_000_000_000_000);
 pub const BASE_GAS: Gas = Gas(5 * TGAS);
 pub const GAS_FOR_ROYALTIES: Gas = Gas(BASE_GAS.0 * 10u64);
+pub const GAS_FOR_RESOLVE_CLAIM_BACK: Gas = Gas(BASE_GAS.0 * 10u64);
 
 pub type LeaseId = String;
 pub type PayoutHashMap = HashMap<AccountId, U128>;
@@ -69,13 +70,15 @@ pub struct NftOnTransferJson {
 pub struct LeaseCondition {
     contract_addr: AccountId, // NFT contract
     token_id: TokenId,        // NFT token
-    owner_id: AccountId,      // Owner of the NFT
-    borrower: AccountId,      // Borrower of the NFT
-    approval_id: u64,         // Approval from owner to lease
-    expiration: u64,          // TODO: duration
-    price: u128,              // Proposed lease price
-    payout: Option<Payout>,   // Payout info (e.g. for Royalty split)
-    state: LeaseState,        // Current lease state
+    // TODO: rename to lender_id
+    owner_id: AccountId, // Owner of the NFT
+    // TODO: rename to borrower_id
+    borrower: AccountId,    // Borrower of the NFT
+    approval_id: u64,       // Approval from owner to lease
+    expiration: u64,        // TODO: duration
+    price: u128,            // Proposed lease price
+    payout: Option<Payout>, // Payout info (e.g. for Royalty split)
+    state: LeaseState,      // Current lease state
 }
 
 #[near_bindgen]
@@ -183,7 +186,7 @@ impl Contract {
         assert_eq!(
             lease_condition.state,
             LeaseState::Active,
-            "Queried Lease is no longer active!"
+            "Queried Lease is not active!"
         );
 
         // 3. only original lender or service contract owner can claim back from expried lease
@@ -193,11 +196,7 @@ impl Contract {
             "Only original lender or service owner can claim back!"
         );
 
-        // 4. send rent to owner
-        // TODO(libo): handle the promise in a transaction
-        self.transfer(lease_condition.owner_id.clone(), lease_condition.price);
-
-        // 5. transfer nft to owner
+        // 4. transfer nft to owner
         ext_nft::ext(lease_condition.contract_addr.clone())
             .with_static_gas(Gas(5 * TGAS))
             .with_attached_deposit(1)
@@ -206,17 +205,39 @@ impl Contract {
                 lease_condition.token_id.clone(),
                 None,
                 None,
+            )
+            // 5. Pay the rent to lender and royalty to relevant parties. Finally remove the lease.
+            .then(
+                ext_self::ext(env::current_account_id())
+                    .with_attached_deposit(0)
+                    .with_static_gas(GAS_FOR_RESOLVE_CLAIM_BACK)
+                    .resolve_claim_back(lease_id),
             );
+    }
 
-        // 6. remove lease record
+    #[private]
+    pub fn resolve_claim_back(&mut self, lease_id: LeaseId) {
+        // TODO: avoid re-fetch lease condition
+        let lease_condition: LeaseCondition = self.lease_map.get(&lease_id).unwrap();
+
+        match lease_condition.payout {
+            Some(payout) => {
+                for (receiver_id, aleount) in payout.seayout {
+                    self.internal_transfer_near(receiver_id, amount.0);
+                }
+            }
+            None => {
+                self.internal_transfer_near(lease_condition.owner_id, lease_condition.price);
+            }
+        }
+
         self.internal_remove_lease(&lease_id)
     }
 
-    fn transfer(&self, to: AccountId, amount: Balance) {
+    fn internal_transfer_near(&self, to: AccountId, amount: Balance) -> Promise {
         // helper function to perform FT transfer
-        Promise::new(to).transfer(amount);
+        Promise::new(to).transfer(amount)
     }
-
     pub fn leases_by_owner(&self, account_id: AccountId) -> Vec<(String, LeaseCondition)> {
         let mut results: Vec<(String, LeaseCondition)> = vec![];
 
@@ -592,11 +613,11 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "Queried Lease is no longer active!")]
+    #[should_panic(expected = "Queried Lease is not active!")]
     fn test_claim_back_inactive_lease() {
         let mut contract = Contract::new(accounts(1).into());
         let mut lease_condition = create_lease_condition_default();
-        lease_condition.state = LeaseState::Expired;
+        lease_condition.state = LeaseState::Pending;
         let key = "test_key".to_string();
 
         contract.lease_map.insert(&key, &lease_condition);
@@ -636,32 +657,62 @@ mod tests {
         lease_condition.state = LeaseState::Active;
         lease_condition.price = 20;
         let key = "test_key".to_string();
-
         contract.internal_insert_lease(&key, &lease_condition);
 
-        let initial_balance: u128 = 100;
-
-        let mut builder = VMContextBuilder::new();
-        testing_env!(builder
+        testing_env!(VMContextBuilder::new()
             .current_account_id(accounts(0))
             .predecessor_account_id(lease_condition.owner_id.clone())
-            .storage_usage(env::storage_usage())
-            .account_balance(initial_balance) //set initial balance
             .block_timestamp(lease_condition.expiration + 1)
             .build());
 
         contract.claim_back(key);
 
-        testing_env!(builder
-            .storage_usage(env::storage_usage())
-            .account_balance(env::account_balance()) // current service account
-            .build());
+        // Nothing can be checked, except the fact the call doesn't panic.
+    }
 
-        assert!(
-            // service account balance should be reduced by the lease amount.
-            // -1 due to gas cost
-            builder.context.account_balance == (initial_balance - lease_condition.price) - 1
-        );
+    #[test]
+    fn test_resolve_claim_back_succeeds_pay_royalty() {
+        let mut contract = Contract::new(accounts(1).into());
+        let mut lease_condition = create_lease_condition_default();
+        lease_condition.state = LeaseState::Active;
+        lease_condition.price = 20;
+        lease_condition.payout = Some(Payout {
+            payout: HashMap::from([(accounts(2), U128::from(5)), (accounts(3), U128::from(15))]),
+        });
+        let key = "test_key".to_string();
+        contract.lease_map.insert(&key, &lease_condition);
+        let init_balance = 100;
+
+        testing_env!(VMContextBuilder::new()
+            .current_account_id(accounts(0))
+            .predecessor_account_id(accounts(0))
+            .account_balance(init_balance)
+            .build());
+        contract.resolve_claim_back(key);
+
+        assert_eq!(env::account_balance(), init_balance - 20);
+        assert!(contract.lease_map.is_empty());
+    }
+
+    #[test]
+    fn test_resolve_claim_back_succeeds_no_payout_info() {
+        let mut contract = Contract::new(accounts(1).into());
+        let mut lease_condition = create_lease_condition_default();
+        lease_condition.state = LeaseState::Active;
+        lease_condition.price = 20;
+        lease_condition.payout = None;
+        let key = "test_key".to_string();
+        contract.lease_map.insert(&key, &lease_condition);
+        let init_balance = 100;
+
+        testing_env!(VMContextBuilder::new()
+            .current_account_id(accounts(0))
+            .predecessor_account_id(accounts(0))
+            .account_balance(init_balance)
+            .build());
+        contract.resolve_claim_back(key);
+
+        assert_eq!(env::account_balance(), init_balance - 20);
         assert!(contract.lease_map.is_empty());
     }
 

--- a/contract/src/lib.rs
+++ b/contract/src/lib.rs
@@ -578,7 +578,7 @@ mod tests {
         let mut lease_condition = create_lease_condition_default();
         lease_condition.state = LeaseState::Active;
         let key = "test_key".to_string();
-        //TODO(syu): update index too
+
         contract.lease_map.insert(&key, &lease_condition);
 
         testing_env!(VMContextBuilder::new()
@@ -597,7 +597,7 @@ mod tests {
         let mut lease_condition = create_lease_condition_default();
         lease_condition.state = LeaseState::Expired;
         let key = "test_key".to_string();
-        //TODO(syu): update index too
+
         contract.lease_map.insert(&key, &lease_condition);
 
         testing_env!(VMContextBuilder::new()
@@ -616,7 +616,6 @@ mod tests {
         let mut lease_condition = create_lease_condition_default();
         lease_condition.state = LeaseState::Active;
         let key = "test_key".to_string();
-        //TODO(syu): update index too
         contract.lease_map.insert(&key, &lease_condition);
 
         testing_env!(VMContextBuilder::new()
@@ -636,8 +635,8 @@ mod tests {
         lease_condition.state = LeaseState::Active;
         lease_condition.price = 20;
         let key = "test_key".to_string();
-        //TODO(syu): udpate index too
-        contract.lease_map.insert(&key, &lease_condition);
+
+        contract.internal_insert_lease(&key, &lease_condition);
 
         let initial_balance: u128 = 100;
 
@@ -680,7 +679,6 @@ mod tests {
         lease_condition.borrower = expected_borrower_id.clone();
 
         let key = "test_key".to_string();
-        //TODO: update index
         contract.lease_map.insert(&key, &lease_condition);
 
         testing_env!(VMContextBuilder::new()
@@ -715,7 +713,6 @@ mod tests {
         lease_condition.borrower = expected_borrower_id.clone();
 
         let key = "test_key".to_string();
-        //TODO: update index
         contract.lease_map.insert(&key, &lease_condition);
 
         testing_env!(VMContextBuilder::new()
@@ -740,8 +737,7 @@ mod tests {
         lease_condition_1.borrower = expected_borrower_id.clone();
 
         let key_1 = "test_key_1".to_string();
-        // TODO: update index
-        contract.lease_map.insert(&key_1, &lease_condition_1);
+        contract.internal_insert_lease(&key_1, &lease_condition_1);
 
         let mut lease_condition_2 = create_lease_condition_default();
         lease_condition_2.state = LeaseState::Active;
@@ -749,7 +745,7 @@ mod tests {
         lease_condition_2.borrower = expected_borrower_id.clone();
 
         let key_2 = "test_key_2".to_string();
-        contract.lease_map.insert(&key_2, &lease_condition_2);
+        contract.internal_insert_lease(&key_2, &lease_condition_2);
 
         testing_env!(VMContextBuilder::new()
             .current_account_id(accounts(0))
@@ -772,8 +768,7 @@ mod tests {
         lease_condition_1.owner_id = expected_owner_id.clone();
 
         let key_1 = "test_key_1".to_string();
-        // TODO: update index
-        contract.lease_map.insert(&key_1, &lease_condition_1);
+        contract.internal_insert_lease(&key_1, &lease_condition_1);
 
         let mut lease_condition_2 = create_lease_condition_default();
         lease_condition_2.state = LeaseState::Active;
@@ -781,7 +776,7 @@ mod tests {
         lease_condition_2.owner_id = expected_owner_id.clone();
 
         let key_2 = "test_key_2".to_string();
-        contract.lease_map.insert(&key_2, &lease_condition_2);
+        contract.internal_insert_lease(&key_2, &lease_condition_2);
 
         let mut builder = VMContextBuilder::new();
         testing_env!(builder

--- a/contract/src/lib.rs
+++ b/contract/src/lib.rs
@@ -829,6 +829,72 @@ mod tests {
         assert!(!contract.lease_ids_by_lender.contains_key(&lease_condition.owner_id));
     }
 
+    #[test]
+    fn test_internal_remove_lease_success_different_owners(){
+        let mut contract = Contract::new(accounts(1).into());
+        let owner_1: AccountId = accounts(2).into();
+        let owner_2: AccountId = accounts(4).into();
+
+        let mut lease_condition_1 = create_lease_condition_default();
+        lease_condition_1.state = LeaseState::Active;
+        lease_condition_1.token_id = "test_token_1".to_string();
+        lease_condition_1.owner_id = owner_1.clone();
+
+        let key_1 = "test_key_1".to_string();
+        contract.internal_insert_lease(&key_1, &lease_condition_1);
+
+        let mut lease_condition_2 = create_lease_condition_default();
+        lease_condition_2.state = LeaseState::Active;
+        lease_condition_2.token_id = "test_token_2".to_string();
+        lease_condition_2.owner_id = owner_2.clone();
+
+        let key_2 = "test_key_2".to_string();
+        contract.internal_insert_lease(&key_2, &lease_condition_2);
+
+        assert!(contract.lease_map.len()==2);
+        assert!(contract.lease_ids_by_lender.contains_key(&owner_1));
+        assert!(contract.lease_ids_by_lender.contains_key(&owner_2));
+
+        contract.internal_remove_lease(&key_1);
+
+        assert!(contract.lease_map.len()==1);
+        assert!(!contract.lease_ids_by_lender.contains_key(&owner_1));
+        assert!(contract.lease_ids_by_lender.contains_key(&owner_2));
+    }
+
+    #[test]
+    fn test_internal_remove_lease_success_different_borrowers(){
+        let mut contract = Contract::new(accounts(1).into());
+        let borrower_1: AccountId = accounts(3).into();
+        let borrower_2: AccountId = accounts(4).into();
+
+        let mut lease_condition_1 = create_lease_condition_default();
+        lease_condition_1.state = LeaseState::Active;
+        lease_condition_1.token_id = "test_token_1".to_string();
+        lease_condition_1.borrower = borrower_1.clone();
+
+        let key_1 = "test_key_1".to_string();
+        contract.internal_insert_lease(&key_1, &lease_condition_1);
+
+        let mut lease_condition_2 = create_lease_condition_default();
+        lease_condition_2.state = LeaseState::Active;
+        lease_condition_2.token_id = "test_token_2".to_string();
+        lease_condition_2.borrower = borrower_2.clone();
+
+        let key_2 = "test_key_2".to_string();
+        contract.internal_insert_lease(&key_2, &lease_condition_2);
+
+        assert!(contract.lease_map.len()==2);
+        assert!(contract.lease_ids_by_borrower.contains_key(&borrower_1));
+        assert!(contract.lease_ids_by_borrower.contains_key(&borrower_2));
+
+        contract.internal_remove_lease(&key_1);
+
+        assert!(contract.lease_map.len()==1);
+        assert!(!contract.lease_ids_by_borrower.contains_key(&borrower_1));
+        assert!(contract.lease_ids_by_borrower.contains_key(&borrower_2));
+    }
+
     // Helper function to return a lease condition using default seting
     fn create_lease_condition_default() -> LeaseCondition {
         let token_id: TokenId = "test_token".to_string();

--- a/contract/src/lib.rs
+++ b/contract/src/lib.rs
@@ -211,7 +211,6 @@ impl Contract {
         self.internal_remove_lease(&lease_id)
     }
 
-
     fn transfer(&self, to: AccountId, amount: Balance) {
         // helper function to perform FT transfer
         Promise::new(to).transfer(amount);
@@ -219,9 +218,9 @@ impl Contract {
 
     pub fn leases_by_owner(&self, account_id: AccountId) -> Vec<(String, LeaseCondition)> {
         let mut results: Vec<(String, LeaseCondition)> = vec![];
-        
-        let lease_ids = self.lease_ids_by_borrower.get(&account_id).unwrap();
-        for id in lease_ids.iter(){
+
+        let lease_ids = self.lease_ids_by_lender.get(&account_id).unwrap();
+        for id in lease_ids.iter() {
             let lease_condition = self.lease_map.get(&id).unwrap();
             results.push((id, lease_condition));
         }
@@ -315,11 +314,7 @@ impl Contract {
     }
 
     // helper method to insert a new lease and update all indices
-    fn internal_insert_lease(
-        &mut self,
-        lease_id: &LeaseId,
-        lease_condition: &LeaseCondition,
-    ) {
+    fn internal_insert_lease(&mut self, lease_id: &LeaseId, lease_condition: &LeaseCondition) {
         // insert into lease map
         self.lease_map.insert(&lease_id, &lease_condition);
 
@@ -412,7 +407,6 @@ impl NonFungibleTokenApprovalsReceiver for Contract {
             .into_string();
 
         self.internal_insert_lease(&lease_id, &lease_condition);
-
     }
 }
 

--- a/contract/src/lib.rs
+++ b/contract/src/lib.rs
@@ -789,6 +789,46 @@ mod tests {
         assert_eq!(result.len(), 2);
     }
 
+    #[test]
+    fn test_internal_insert_lease_success(){
+        let mut contract = Contract::new(accounts(1).into());
+        let mut lease_condition = create_lease_condition_default();
+        lease_condition.state = LeaseState::Active;
+        lease_condition.price = 20;
+        let key = "test_key".to_string();
+
+        assert!(contract.lease_map.is_empty());
+        assert!(!contract.lease_ids_by_borrower.contains_key(&lease_condition.borrower));
+        assert!(!contract.lease_ids_by_lender.contains_key(&lease_condition.owner_id));
+
+        contract.internal_insert_lease(&key, &lease_condition);
+
+        assert!(contract.lease_map.len() == 1);
+        assert!(contract.lease_ids_by_borrower.contains_key(&lease_condition.borrower));
+        assert!(contract.lease_ids_by_lender.contains_key(&lease_condition.owner_id));
+    }
+
+    #[test]
+    fn test_internal_remove_lease_success_only_one_lease(){
+        let mut contract = Contract::new(accounts(1).into());
+        let mut lease_condition = create_lease_condition_default();
+        lease_condition.state = LeaseState::Active;
+        lease_condition.price = 20;
+        let key = "test_key".to_string();
+
+        contract.internal_insert_lease(&key, &lease_condition);
+
+        assert!(contract.lease_map.len() == 1);
+        assert!(contract.lease_ids_by_borrower.contains_key(&lease_condition.borrower));
+        assert!(contract.lease_ids_by_lender.contains_key(&lease_condition.owner_id));
+
+        contract.internal_remove_lease(&key);
+
+        assert!(contract.lease_map.is_empty());
+        assert!(!contract.lease_ids_by_borrower.contains_key(&lease_condition.borrower));
+        assert!(!contract.lease_ids_by_lender.contains_key(&lease_condition.owner_id));
+    }
+
     // Helper function to return a lease condition using default seting
     fn create_lease_condition_default() -> LeaseCondition {
         let token_id: TokenId = "test_token".to_string();

--- a/contract/src/lib.rs
+++ b/contract/src/lib.rs
@@ -221,7 +221,7 @@ impl Contract {
 
         match lease_condition.payout {
             Some(payout) => {
-                for (receiver_id, aleount) in payout.seayout {
+                for (receiver_id, amount) in payout.payout {
                     self.internal_transfer_near(receiver_id, amount.0);
                 }
             }

--- a/contract/src/lib.rs
+++ b/contract/src/lib.rs
@@ -219,13 +219,14 @@ impl Contract {
 
     pub fn leases_by_owner(&self, account_id: AccountId) -> Vec<(String, LeaseCondition)> {
         let mut results: Vec<(String, LeaseCondition)> = vec![];
-        // TODO: use better data structure to optimise this operation.
-        for lease in self.lease_map.iter() {
-            if lease.1.owner_id == account_id {
-                results.push(lease)
-            }
+        
+        let lease_ids = self.lease_ids_by_borrower.get(&account_id).unwrap();
+        for id in lease_ids.iter(){
+            let lease_condition = self.lease_map.get(&id).unwrap();
+            results.push((id, lease_condition));
         }
-        results
+
+        return results;
     }
 
     pub fn leases_by_borrower(&self, account_id: AccountId) -> Vec<(String, LeaseCondition)> {
@@ -241,7 +242,7 @@ impl Contract {
 
     pub fn get_borrower(&self, contract_id: AccountId, token_id: TokenId) -> Option<AccountId> {
         // return the current borrower of the NFTs
-        // TODO: use better data structure to optimise this operation. Can a NFT contract hold this info?
+        // TODO: use better data structure to optimise this operation. Can a NFT contract keep this info?
         for lease in self.lease_map.iter() {
             if (lease.1.contract_addr == contract_id) && (lease.1.token_id == token_id) {
                 return Some(lease.1.borrower);
@@ -275,7 +276,7 @@ impl Contract {
 
     // helper method to remove records of a lease
     fn internal_remove_lease(&mut self, lease_id: &LeaseId) {
-        // check if a leasecondition exist
+        // check if a lease condition exist
         let lease_condition = self
             .lease_map
             .get(&lease_id)

--- a/contract/src/lib.rs
+++ b/contract/src/lib.rs
@@ -83,8 +83,9 @@ pub struct LeaseCondition {
 pub struct Contract {
     owner: AccountId,
     lease_map: UnorderedMap<LeaseId, LeaseCondition>,
-    lease_ids_by_lender: LookupMap<AccountId, UnorderedSet<LeaseId>>, // helper index
-    lease_ids_by_borrower: LookupMap<AccountId, UnorderedSet<LeaseId>>, // helper index
+    lease_ids_by_lender: LookupMap<AccountId, UnorderedSet<LeaseId>>,
+    lease_ids_by_borrower: LookupMap<AccountId, UnorderedSet<LeaseId>>,
+    // borrower_by_contract_addr_and_token_id = UnorderedMap<(AccountId, TokenId), AccountId> // to help implement get_borrower()
 }
 
 #[derive(BorshStorageKey, BorshSerialize)]
@@ -219,7 +220,7 @@ impl Contract {
     pub fn leases_by_owner(&self, account_id: AccountId) -> Vec<(String, LeaseCondition)> {
         let mut results: Vec<(String, LeaseCondition)> = vec![];
 
-        let lease_ids = self.lease_ids_by_lender.get(&account_id).unwrap();
+        let lease_ids = self.lease_ids_by_lender.get(&account_id).unwrap_or(UnorderedSet::new(b"s"));
         for id in lease_ids.iter() {
             let lease_condition = self.lease_map.get(&id).unwrap();
             results.push((id, lease_condition));

--- a/integration-tests/tests/integration.rs
+++ b/integration-tests/tests/integration.rs
@@ -201,3 +201,4 @@ async fn test_claim_back_success() -> anyhow::Result<()> {
 // TODO: lending_accept - NFT has been transferred to other account
 // TODO: claim_back - NFT transfer check
 // TODO: claim_back - check lease amount recieval, probably by using ft_balance_of().
+// TODO: nft_on_approve - check all indices have been updated accordingly

--- a/integration-tests/tests/integration.rs
+++ b/integration-tests/tests/integration.rs
@@ -201,4 +201,4 @@ async fn test_claim_back_success() -> anyhow::Result<()> {
 // TODO: lending_accept - NFT has been transferred to other account
 // TODO: claim_back - NFT transfer check
 // TODO: claim_back - check lease amount recieval, probably by using ft_balance_of().
-// TODO: nft_on_approve - check all indices have been updated accordingly
+// TODO: nft_on_approve - check lease createion happened correctly & all indices have been updated accordingly


### PR DESCRIPTION
[NR-36](https://linear.app/niftyrent/issue/NR-36/lookup-functions-are-too-expensive)

### Changes
- Added 2 lookup indices:  lease_ids_by_lender & lease_ids_by_borrower
- Adjusted code to reflect indices update (lease add, lease remove)
- Adjusted test cases and add new test cases for internal methods

### Test output

- Unit test result:

<img width="683" alt="Screenshot 2022-12-17 at 00 32 03" src="https://user-images.githubusercontent.com/5934114/208213380-0b94b982-e6c4-49e6-adb1-9472e20320fa.png">


- Integration test result:
<img width="699" alt="Screenshot 2022-12-17 at 00 33 52" src="https://user-images.githubusercontent.com/5934114/208213280-ed1147a8-5062-44fb-9646-4f9a87ca7b0b.png">
