### PR TITLE
[NR67][NR42]Add index to support get_borrower & add lease state check to get_borrower

### DIFF
--- a/contract/src/lib.rs
+++ b/contract/src/lib.rs
@@ -768,11 +768,6 @@ mod tests {
         let key = "test_key".to_string();
         contract.internal_insert_lease(&key, &lease_condition);
 
-        testing_env!(VMContextBuilder::new()
-            .current_account_id(accounts(0))
-            .predecessor_account_id(lease_condition.owner_id.clone())
-            .build());
-
         let test_contract_id: AccountId = accounts(5).into();
         let test_token_id = "dummy_token".to_string();
 
@@ -802,11 +797,6 @@ mod tests {
         let key = "test_key".to_string();
         contract.internal_insert_lease(&key, &lease_condition);
 
-        testing_env!(VMContextBuilder::new()
-            .current_account_id(accounts(0))
-            .predecessor_account_id(lease_condition.owner_id.clone())
-            .build());
-
         let result_borrower = contract
             .get_borrower_by_contract_and_token(expected_contract_address, expected_token_id);
         assert!(result_borrower.is_none());
@@ -828,11 +818,6 @@ mod tests {
 
         let key = "test_key".to_string();
         contract.internal_insert_lease(&key, &lease_condition);
-
-        testing_env!(VMContextBuilder::new()
-            .current_account_id(accounts(0))
-            .predecessor_account_id(lease_condition.owner_id.clone())
-            .build());
 
         let result_borrower = contract
             .get_borrower_by_contract_and_token(expected_contract_address, expected_token_id)

--- a/contract/src/lib.rs
+++ b/contract/src/lib.rs
@@ -87,9 +87,7 @@ pub struct Contract {
     lease_map: UnorderedMap<LeaseId, LeaseCondition>,
     lease_ids_by_lender: LookupMap<AccountId, UnorderedSet<LeaseId>>,
     lease_ids_by_borrower: LookupMap<AccountId, UnorderedSet<LeaseId>>,
-    // borrower_by_contract_addr_and_token_id = UnorderedMap<(AccountId, TokenId), AccountId> // to help implement get_borrower()
-    // TODO: deside if one token can be in multiple lease
-    lease_id_by_contract_addr_and_token_id: LookupMap<(AccountId, TokenId), LeaseId>, // only active leases
+    lease_id_by_contract_addr_and_token_id: LookupMap<(AccountId, TokenId), LeaseId>,
 }
 
 #[derive(BorshStorageKey, BorshSerialize)]
@@ -273,7 +271,7 @@ impl Contract {
         return results;
     }
 
-    pub fn get_borrower(&self, contract_id: AccountId, token_id: TokenId) -> Option<AccountId> {
+    pub fn get_borrower_by_contract_and_token(&self, contract_id: AccountId, token_id: TokenId) -> Option<AccountId> {
         // return the current borrower of the NFTs
         // Only active lease has valid borrower
 
@@ -754,7 +752,7 @@ mod tests {
     }
 
     #[test]
-    fn test_get_borrower_no_matching_borrower() {
+    fn test_get_borrower_by_contract_and_token_success_no_matching_borrower() {
         let mut contract = Contract::new(accounts(1).into());
         let mut lease_condition = create_lease_condition_default();
 
@@ -779,16 +777,16 @@ mod tests {
         let test_token_id = "dummy_token".to_string();
 
         let result_borrower =
-            contract.get_borrower(test_contract_id.clone(), expected_token_id.clone());
+            contract.get_borrower_by_contract_and_token(test_contract_id.clone(), expected_token_id.clone());
         assert!(result_borrower.is_none());
 
         let result_borrower =
-            contract.get_borrower(expected_contract_address.clone(), test_token_id.clone());
+            contract.get_borrower_by_contract_and_token(expected_contract_address.clone(), test_token_id.clone());
         assert!(result_borrower.is_none());
     }
 
     #[test]
-    fn test_get_borrower_lease_is_inactive(){
+    fn test_get_borrower_by_contract_and_token_success_lease_is_inactive(){
         let mut contract = Contract::new(accounts(1).into());
         let mut lease_condition = create_lease_condition_default();
 
@@ -811,12 +809,12 @@ mod tests {
             .build());
 
         let result_borrower = contract
-            .get_borrower(expected_contract_address, expected_token_id);
+            .get_borrower_by_contract_and_token(expected_contract_address, expected_token_id);
         assert!(result_borrower.is_none());
     }
 
     #[test]
-    fn test_get_borrower_success_found_matching_borrower() {
+    fn test_get_borrower_by_contract_and_token_success_found_matching_borrower() {
         let mut contract = Contract::new(accounts(1).into());
         let mut lease_condition = create_lease_condition_default();
 
@@ -839,7 +837,7 @@ mod tests {
             .build());
 
         let result_borrower = contract
-            .get_borrower(expected_contract_address, expected_token_id)
+            .get_borrower_by_contract_and_token(expected_contract_address, expected_token_id)
             .unwrap();
         assert!(contract
             .lease_id_by_contract_addr_and_token_id

--- a/contract/src/lib.rs
+++ b/contract/src/lib.rs
@@ -800,7 +800,6 @@ mod tests {
         lease_condition.borrower = expected_borrower_id.clone();
 
         let key = "test_key".to_string();
-        // contract.lease_map.insert(&key, &lease_condition);
         contract.internal_insert_lease(&key, &lease_condition);
 
         testing_env!(VMContextBuilder::new()
@@ -828,7 +827,6 @@ mod tests {
         lease_condition.borrower = expected_borrower_id.clone();
 
         let key = "test_key".to_string();
-        // contract.lease_map.insert(&key, &lease_condition);
         contract.internal_insert_lease(&key, &lease_condition);
 
         testing_env!(VMContextBuilder::new()
@@ -839,9 +837,6 @@ mod tests {
         let result_borrower = contract
             .get_borrower_by_contract_and_token(expected_contract_address, expected_token_id)
             .unwrap();
-        assert!(contract
-            .lease_id_by_contract_addr_and_token_id
-            .contains_key(&(lease_condition.contract_addr, lease_condition.token_id)));
         assert!(result_borrower == expected_borrower_id);
     }
 

--- a/integration-tests/tests/integration.rs
+++ b/integration-tests/tests/integration.rs
@@ -158,7 +158,7 @@ async fn test_claim_back_success() -> anyhow::Result<()> {
 
     println!("Confirm the lease is activated ...");
     let borrower_id_result: String = borrower
-        .call(contract.id(), "get_borrower")
+        .call(contract.id(), "get_borrower_by_contract_and_token")
         .args_json(json!({
             "contract_id": nft_contract.id(),
             "token_id": token_id,


### PR DESCRIPTION
### Context
[NR-67](https://linear.app/niftyrent/issue/NR-67/add-index-to-optimise-get-borrower) 
[NR-42](https://linear.app/niftyrent/issue/NR-42/get-borrower-should-return-none-when-the-lease-is-expired)

Previously, get_borrower iterates the whole lease map to find the matching borrower. It is not gas efficient
The method is also not checking lease status, where only active lease should be counted

### Solution & Code change
- A new index _lease_id_by_contract_addr_and_token_id_ is added, which can then use lease_map to get the matching borrower. This design is easier to be extended in the future when other lease info needs to be queried given (contract_addr, token_id). 
- Lease state check added in the method when matching lease is found
- Updated the method name to be more descriptive
- Adjusted code to maintain the new index at insertion and removal
- Added unit tests

### Test
- unit test
<img width="705" alt="Screenshot 2022-12-21 at 00 03 38" src="https://user-images.githubusercontent.com/5934114/208790014-26092950-0c61-4520-bcf0-c654fad8b8db.png">
- integration test
<img width="749" alt="Screenshot 2022-12-21 at 00 08 11" src="https://user-images.githubusercontent.com/5934114/208790448-674ce754-217f-4826-afa7-6868c1c20146.png">


