### PR TITLE
[NR-61] check the sum of the payout values should match the price

### DIFF
--- a/contract/src/lib.rs
+++ b/contract/src/lib.rs
@@ -632,7 +632,7 @@ mod tests {
 
     #[test]
     #[should_panic(
-        expected = "assertion failed: `(left == right)`\n  left: `3`,\n right: `5`: The sum of payout does not match the lease price"
+        expected = "The difference between the lease price and the sum of payout is too large"
     )]
     fn test_activate_lease_failure_invalid_payout() {
         let mut contract = Contract::new(accounts(1).into());


### PR DESCRIPTION
When the lender attempts to accept the lending, payout will be calculated by the given NFT, and we will verify if the sum of payout equals to the lease price. If not, we will throw exception and abort the call. 

Test plan:
Unit test. 