### PR TITLE
Check lease state when calling `lending_accept`

### DIFF
--- a/contract/src/externals.rs
+++ b/contract/src/externals.rs
@@ -30,4 +30,6 @@ pub trait Nft {
         balance: U128,
         max_len_payout: Option<u32>,
     );
+
+    fn nft_token(&self, token_id: TokenId) -> Option<Token>;
 }

--- a/contract/src/externals.rs
+++ b/contract/src/externals.rs
@@ -30,6 +30,4 @@ pub trait Nft {
         balance: U128,
         max_len_payout: Option<u32>,
     );
-
-    fn nft_token(&self, token_id: TokenId) -> Option<Token>;
 }

--- a/integration-tests/tests/integration.rs
+++ b/integration-tests/tests/integration.rs
@@ -324,6 +324,16 @@ async fn test_accept_lease_fails_already_transferred() -> anyhow::Result<()> {
         .await?
         .into_result()?;
 
+    // Verify the ownership of the token has been updated
+    let token:Token = nft_contract
+        .view("nft_token")
+        .args_json(json!({
+            "token_id": token_id,
+        }))
+        .await?
+        .json()?;
+    assert_eq!(token.owner_id.to_string(), new_owner.id().to_string());
+
     // Confirming the created lease ...
     let leases: Vec<(String, LeaseCondition)> = contract
         .call("leases_by_owner")
@@ -350,8 +360,17 @@ async fn test_accept_lease_fails_already_transferred() -> anyhow::Result<()> {
         .transact()
         .await?
         .json()?;
-    assert_eq!(updated_leases[0].1.state, LeaseState::Pending);
+    // assert_eq!(updated_leases[0].1.state, LeaseState::Pending);
     println!("      Lease cannot be accepted by Bob");
+    let token:Token = nft_contract
+        .view("nft_token")
+        .args_json(json!({
+            "token_id": token_id,
+        }))
+        .await?
+        .json()?;
+    println!("token: {:?}", token);
+    assert_eq!(token.owner_id.to_string(), new_owner.id().to_string());
     Ok(())
 }
 

--- a/integration-tests/tests/integration.rs
+++ b/integration-tests/tests/integration.rs
@@ -345,9 +345,8 @@ async fn test_lending_nft_transferred() -> anyhow::Result<()> {
         .transact()
         .await?
         .into_result()?;
-    println!("      ✅ Lease accepted by Bob");
-    println!("      ✅ Lease activation accepted between Alice and Bob");
-
+    assert_eq!(leases[0].1.state, LeaseState::Pending);
+    println!("      Lease cannot be accepted by Bob");
     Ok(())
 }
 

--- a/integration-tests/tests/integration.rs
+++ b/integration-tests/tests/integration.rs
@@ -264,6 +264,8 @@ async fn test_accept_leases_already_lent() -> anyhow::Result<()> {
     println!("      ✅ Lease accepted by Bob");
 
     // Bob tries to accept the lease again.
+    // This action should fail
+    // TODO(haichen): make lending_accept fail explicitly
     borrower
     .call(contract.id(), "lending_accept")
     .args_json(json!({
@@ -274,7 +276,6 @@ async fn test_accept_leases_already_lent() -> anyhow::Result<()> {
     .transact()
     .await?
     .into_result()?;
-    println!("      ✅ Lease accepted by Bob");
 
     println!("Charlse tries to accept the same lease ...");
     let result = borrower_failed

--- a/integration-tests/tests/integration.rs
+++ b/integration-tests/tests/integration.rs
@@ -333,6 +333,7 @@ async fn test_accept_lease_fails_already_transferred() -> anyhow::Result<()> {
         .await?
         .json()?;
     assert_eq!(token.owner_id.to_string(), new_owner.id().to_string());
+    println!("       ✅ The token is still owned by Charlse");
 
     // Confirming the created lease ...
     let leases: Vec<(String, LeaseCondition)> = contract
@@ -360,8 +361,8 @@ async fn test_accept_lease_fails_already_transferred() -> anyhow::Result<()> {
         .transact()
         .await?
         .json()?;
-    // assert_eq!(updated_leases[0].1.state, LeaseState::Pending);
-    println!("      Lease cannot be accepted by Bob");
+    assert_eq!(updated_leases[0].1.state, LeaseState::Pending);
+    println!("       ✅ Lease cannot be accepted by Bob");
     let token:Token = nft_contract
         .view("nft_token")
         .args_json(json!({
@@ -369,8 +370,8 @@ async fn test_accept_lease_fails_already_transferred() -> anyhow::Result<()> {
         }))
         .await?
         .json()?;
-    println!("token: {:?}", token);
     assert_eq!(token.owner_id.to_string(), new_owner.id().to_string());
+    println!("       ✅ The token is still owned by Charlse");
     Ok(())
 }
 


### PR DESCRIPTION
To avoid borrowers accept the same lease for multiple times or accept an expired lease. 

Test plan:
unit test