### PR TITLE
Fetch NFT media via Mintbase

### DIFF
--- a/frontend/src/AutoInput.jsx
+++ b/frontend/src/AutoInput.jsx
@@ -6,25 +6,26 @@ function classNames(...classes) {
   return classes.filter(Boolean).join(" ");
 }
 
-export default function AutoInput({ selected, setSelected, options }) {
+export default function AutoInput({ selected, setSelected, options, disabled, loading }) {
   const [query, setQuery] = useState("");
 
+  options = options || []
   const filteredOptions =
     query === ""
       ? options.slice(0, 10)
       : options
-          .filter((option) => {
-            return option.name.toLowerCase().includes(query.toLowerCase());
-          })
-          .slice(0, 10);
+        .filter((option) => {
+          return option.name.toLowerCase().includes(query.toLowerCase());
+        })
+        .slice(0, 10);
 
   return (
-    <Combobox as="div" value={selected} onChange={setSelected}>
+    <Combobox as="div" value={selected} onChange={setSelected} disabled={disabled}>
       <div className="relative mt-1">
         <Combobox.Input
           className="w-full rounded-md border border-gray-300 bg-white py-2 pl-3 pr-10 shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500 sm:text-sm"
           onChange={(event) => setQuery(event.target.value)}
-          displayValue={(option) => option?.name}
+          displayValue={(option) => loading ? "Loading ..." : option?.name}
         />
         <Combobox.Button className="absolute inset-y-0 right-0 flex items-center rounded-r-md px-2 focus:outline-none">
           <ChevronUpDownIcon


### PR DESCRIPTION
Use Mintbase indexer and GraphQL API for the NFT lookup.

It eliminates the hassle of dealing with different metadata formats.

Particularly, it improves the user experience for lending Mintbase NFTs. Now the token name and image preview work properly.

E.g.

![image](https://user-images.githubusercontent.com/5186665/210877795-de1dd59a-fe13-4dc2-8578-23ae8aff8a37.png)
https://testnet.mintbase.io/contract/libotest.mintspace2.testnet/token/1
