### PR TITLE
Remove outdated README for contract

### DIFF
--- a/contract/README.md
+++ b/contract/README.md
@@ -1,7 +1,7 @@
-Hello NEAR!
+Welcome to NiFTyRent!
 =================================
 
-A [smart contract] written in [Rust] for an app initialized with [create-near-app]
+The [smart contract] written in [Rust] for [NiFTyRent].
 
 
 Quick Start
@@ -9,16 +9,16 @@ Quick Start
 
 Before you compile this code, you will need to install Rust with [correct target]
 
+Please also refer to ~/README.md for setup.
+
 Exploring The Code
 ==================
 
 1. The main smart contract code lives in `src/lib.rs`.
-2. There are two functions to the smart contract: `get_greeting` and `set_greeting`.
-3. Tests: You can run smart contract tests with the `cargo test`.
+2. Tests: You can run unit tests with the `yarn test:unit`.
 
 
   [smart contract]: https://docs.near.org/develop/welcome
   [Rust]: https://www.rust-lang.org/
-  [create-near-app]: https://github.com/near/create-near-app
+  [NiFTyRent]: https://testnet.niftyrent.xyz/
   [correct target]: https://docs.near.org/develop/prerequisites#rust-and-wasm
-  [cargo]: https://doc.rust-lang.org/book/ch01-03-hello-cargo.html


### PR DESCRIPTION
Small PR to removed the outdated Readme for contract file, that is auto-generated by near tutorial.
This is to remove any confusion for grantee reviewer. More description can be added later.