### PR TITLE
[NR-75] Fetch payout info when creating the lease

### DIFF
--- a/contract/src/externals.rs
+++ b/contract/src/externals.rs
@@ -5,6 +5,16 @@ use crate::*;
 trait ExtSelf {
     fn activate_lease(&mut self, lease_id: LeaseId) -> Promise;
     fn resolve_claim_back(&mut self, lease_id: LeaseId) -> Promise;
+    fn create_lease_with_payout(
+        &mut self,
+        contract_id: AccountId,
+        token_id: TokenId,
+        owner_id: AccountId,
+        borrower_id: AccountId,
+        expiration: u64,
+        price: u128,
+        approval_id: u64,
+    ) -> Promise;
 }
 
 /// NFT interface, for cross-contract calls
@@ -30,4 +40,6 @@ pub trait Nft {
         balance: U128,
         max_len_payout: Option<u32>,
     );
+
+    fn nft_payout(self, token_id: String, balance: U128, max_len_payout: u32) -> Payout;
 }

--- a/contract/src/externals.rs
+++ b/contract/src/externals.rs
@@ -41,5 +41,5 @@ pub trait Nft {
         max_len_payout: Option<u32>,
     );
 
-    fn nft_payout(self, token_id: String, balance: U128, max_len_payout: u32) -> Payout;
+    fn nft_payout(self, token_id: String, balance: U128, max_len_payout: Option<u32>) -> Payout;
 }

--- a/contract/src/lib.rs
+++ b/contract/src/lib.rs
@@ -549,7 +549,7 @@ impl NonFungibleTokenApprovalsReceiver for Contract {
             .nft_payout(
                 lease_json.token_id.clone(),    // token_id
                 U128::from(lease_json.price.0), // price
-                50u32,                          // max_len_payout
+                None,                          // max_len_payout
             ).as_return();
             // .then(
             //     ext_self::ext(env::current_account_id())

--- a/contract/src/lib.rs
+++ b/contract/src/lib.rs
@@ -546,25 +546,27 @@ impl NonFungibleTokenApprovalsReceiver for Contract {
         assert_eq!(token_id, lease_json.token_id);
 
         ext_nft::ext(lease_json.contract_addr.clone())
+            .with_attached_deposit(0)
+            .with_static_gas(GAS_FOR_ROYALTIES)
             .nft_payout(
                 lease_json.token_id.clone(),    // token_id
                 U128::from(lease_json.price.0), // price
                 None,                          // max_len_payout
+            )
+            .then(
+                ext_self::ext(env::current_account_id())
+                    .with_attached_deposit(0)
+                    .with_static_gas(GAS_FOR_ROYALTIES)
+                    .create_lease_with_payout(
+                        lease_json.contract_addr,
+                        lease_json.token_id,
+                        owner_id,
+                        lease_json.borrower_id,
+                        lease_json.expiration,
+                        lease_json.price.0,
+                        approval_id,
+                    ),
             ).as_return();
-            // .then(
-            //     ext_self::ext(env::current_account_id())
-            //         .with_attached_deposit(0)
-            //         .with_static_gas(GAS_FOR_ROYALTIES)
-            //         .create_lease_with_payout(
-            //             lease_json.contract_addr,
-            //             lease_json.token_id,
-            //             owner_id,
-            //             lease_json.borrower_id,
-            //             lease_json.expiration,
-            //             lease_json.price.0,
-            //             approval_id,
-            //         ),
-            // ).as_return();
     }
 }
 

--- a/demo_nft_contract/src/lib.rs
+++ b/demo_nft_contract/src/lib.rs
@@ -114,7 +114,7 @@ impl Contract {
             .mint(token_id, receiver_id, Some(token_metadata))
     }
 
-    pub fn nft_payout(&self, token_id: TokenId, balance: U128, _max_len_payout: u32) -> Payout {
+    pub fn nft_payout(&self, token_id: TokenId, balance: U128, _max_len_payout: Option<u32>) -> Payout {
         let treasury_split = balance.0 / 20;
         let owner_split = balance.0 - treasury_split;
         let owner = self.tokens.owner_by_id.get(&token_id).unwrap();
@@ -135,7 +135,7 @@ impl Contract {
         balance: near_sdk::json_types::U128,
         max_len_payout: u32,
     ) -> Payout {
-        let payout = self.nft_payout(token_id.clone(), balance, max_len_payout);
+        let payout = self.nft_payout(token_id.clone(), balance, Some(max_len_payout));
         self.nft_transfer(receiver_id, token_id.clone(), Some(approval_id), None);
         payout
     }

--- a/integration-tests/tests/integration.rs
+++ b/integration-tests/tests/integration.rs
@@ -199,8 +199,6 @@ async fn test_claim_back_success() -> anyhow::Result<()> {
     let nft_contract_balance_after_claim_back = nft_contract.view_account().await?.balance;
     // This is based on the demo NFT royalty logic: the NFT contract always keep 5% for itself.
     // So the lender get the rest 95% of the rent.
-    println!("lender_balance_after_claim_back {:?}", lender_balance_after_claim_back);
-    println!("nft_contract_balance_after_claim_back {:?}", nft_contract_balance_after_claim_back);
     assert_aprox_eq(
         lender_balance_after_claim_back - lender_balance_before_claim_back,
         price / 20 * 19,

--- a/integration-tests/tests/integration.rs
+++ b/integration-tests/tests/integration.rs
@@ -201,9 +201,8 @@ async fn test_claim_back_success() -> anyhow::Result<()> {
     // So the lender get the rest 95% of the rent.
     println!("lender_balance_after_claim_back {:?}", lender_balance_after_claim_back);
     println!("nft_contract_balance_after_claim_back {:?}", nft_contract_balance_after_claim_back);
-    let tmp:u128 = lender_balance_after_claim_back - lender_balance_before_claim_back;
     assert_aprox_eq(
-        tmp,
+        lender_balance_after_claim_back - lender_balance_before_claim_back,
         price / 20 * 19,
     );
 

--- a/integration-tests/tests/integration.rs
+++ b/integration-tests/tests/integration.rs
@@ -252,6 +252,7 @@ async fn test_accept_leases_already_lent() -> anyhow::Result<()> {
             }).to_string()
         }))
         .deposit(parse_near!("1 N"))
+        .max_gas()
         .transact()
         .await?
         .into_result()?;

--- a/integration-tests/tests/integration.rs
+++ b/integration-tests/tests/integration.rs
@@ -411,3 +411,4 @@ async fn test_accept_lease_fails_already_transferred() -> anyhow::Result<()> {
 // TODO: claim_back - NFT transfer check
 // TODO: claim_back - check lease amount recieval, probably by using ft_balance_of().
 // TODO: nft_on_approve - check lease createion happened correctly & all indices have been updated accordingly
+// TODO: add a dummy NFT contract without payout being implemented to test the related scenarios

--- a/integration-tests/tests/integration.rs
+++ b/integration-tests/tests/integration.rs
@@ -230,183 +230,184 @@ async fn test_claim_back_success() -> anyhow::Result<()> {
 // Alice creates a lease to Bob.
 // Bob can accept the lease for the first time
 // but he should fail if he attempts to accept it for multipe times
-// #[tokio::test]
-// async fn test_accept_leases_already_lent() -> anyhow::Result<()> {
-//     let context = init().await?;
-//     let lender = context.lender;
-//     let borrower = context.borrower;
-//     let contract = context.contract;
-//     let nft_contract = context.nft_contract;
-//     let worker = context.worker;
-//     let token_id = "test";
-//     let latest_block = worker.view_block().await?;
-//     let expiration_ts_nano = latest_block.timestamp() + ONE_BLOCK_IN_NANO * 10;
+#[tokio::test]
+async fn test_accept_leases_already_lent() -> anyhow::Result<()> {
+    let context = init().await?;
+    let lender = context.lender;
+    let borrower = context.borrower;
+    let contract = context.contract;
+    let nft_contract = context.nft_contract;
+    let worker = context.worker;
+    let token_id = "test";
+    let latest_block = worker.view_block().await?;
+    let expiration_ts_nano = latest_block.timestamp() + ONE_BLOCK_IN_NANO * 10;
 
-//     println!("Creating lease ...");
-//     lender
-//         .call(nft_contract.id(), "nft_approve")
-//         .args_json(json!({
-//             "token_id": token_id,
-//             "account_id": contract.id(),
-//             "msg": json!({"contract_addr": nft_contract.id(),
-//                           "token_id": token_id,
-//                           "borrower_id": borrower.id(),
-//                           "expiration": expiration_ts_nano,
-//                           "price": "1"
-//             }).to_string()
-//         }))
-//         .deposit(parse_near!("1 N"))
-//         .max_gas()
-//         .transact()
-//         .await?
-//         .into_result()?;
-//     println!("      ✅ Lease created and pending on Bob's acceptence");
+    println!("Creating lease ...");
+    lender
+        .call(nft_contract.id(), "nft_approve")
+        .args_json(json!({
+            "token_id": token_id,
+            "account_id": contract.id(),
+            "msg": json!({"contract_addr": nft_contract.id(),
+                          "token_id": token_id,
+                          "borrower_id": borrower.id(),
+                          "expiration": expiration_ts_nano,
+                          "price": "1"
+            }).to_string()
+        }))
+        .deposit(parse_near!("1 N"))
+        .max_gas()
+        .transact()
+        .await?
+        .into_result()?;
+    println!("      ✅ Lease created and pending on Bob's acceptence");
 
-//     // Confirming the created lease ...
-//     let leases: Vec<(String, LeaseCondition)> = contract
-//         .call("leases_by_owner")
-//         .args_json(json!({"account_id": lender.id()}))
-//         .transact()
-//         .await?
-//         .json()?;
+    // Confirming the created lease ...
+    let leases: Vec<(String, LeaseCondition)> = contract
+        .call("leases_by_owner")
+        .args_json(json!({"account_id": lender.id()}))
+        .transact()
+        .await?
+        .json()?;
 
-//     let lease_id = &leases[0].0;
-//     borrower
-//         .call(contract.id(), "lending_accept")
-//         .args_json(json!({
-//             "lease_id": lease_id,
-//         }))
-//         .deposit(1)
-//         .max_gas()
-//         .transact()
-//         .await?
-//         .into_result()?;
+    let lease_id = &leases[0].0;
+    borrower
+        .call(contract.id(), "lending_accept")
+        .args_json(json!({
+            "lease_id": lease_id,
+        }))
+        .deposit(1)
+        .max_gas()
+        .transact()
+        .await?
+        .into_result()?;
 
-//     let leases_updated: Vec<(String, LeaseCondition)> = contract
-//         .call("leases_by_owner")
-//         .args_json(json!({"account_id": lender.id()}))
-//         .transact()
-//         .await?
-//         .json()?;
-//     assert_eq!(leases_updated[0].1.state, LeaseState::Active);
-//     println!("      ✅ Lease accepted by Bob");
+    let leases_updated: Vec<(String, LeaseCondition)> = contract
+        .call("leases_by_owner")
+        .args_json(json!({"account_id": lender.id()}))
+        .transact()
+        .await?
+        .json()?;
+    assert_eq!(leases_updated[0].1.state, LeaseState::Active);
+    println!("      ✅ Lease accepted by Bob");
 
-//     // Bob tries to accept the lease again.
-//     // This action should fail
-//     // TODO(haichen): make lending_accept fail explicitly
-//     let double_accept_result = borrower
-//         .call(contract.id(), "lending_accept")
-//         .args_json(json!({
-//             "lease_id": lease_id,
-//         }))
-//         .deposit(1)
-//         .max_gas()
-//         .transact()
-//         .await?
-//         .into_result();
-//     assert!(double_accept_result.is_err());
-//     println!("      ✅ Lease cannot be accepted by Bob again.");
-//     Ok(())
-// }
+    // Bob tries to accept the lease again.
+    // This action should fail
+    // TODO(haichen): make lending_accept fail explicitly
+    let double_accept_result = borrower
+        .call(contract.id(), "lending_accept")
+        .args_json(json!({
+            "lease_id": lease_id,
+        }))
+        .deposit(1)
+        .max_gas()
+        .transact()
+        .await?
+        .into_result();
+    assert!(double_accept_result.is_err());
+    println!("      ✅ Lease cannot be accepted by Bob again.");
+    Ok(())
+}
 
-// #[tokio::test]
-// async fn test_accept_lease_fails_already_transferred() -> anyhow::Result<()> {
-//     let context = init().await?;
-//     let lender = context.lender;
-//     let borrower = context.borrower;
+#[tokio::test]
+async fn test_accept_lease_fails_already_transferred() -> anyhow::Result<()> {
+    let context = init().await?;
+    let lender = context.lender;
+    let borrower = context.borrower;
 
-//     let worker = workspaces::sandbox().await?;
-//     let account = worker.dev_create_account().await?;
-//     let new_owner = account
-//         .create_subaccount("charles")
-//         .initial_balance(parse_near!("30 N"))
-//         .transact()
-//         .await?
-//         .into_result()?;
+    let worker = workspaces::sandbox().await?;
+    let account = worker.dev_create_account().await?;
+    let new_owner = account
+        .create_subaccount("charles")
+        .initial_balance(parse_near!("30 N"))
+        .transact()
+        .await?
+        .into_result()?;
 
-//     let contract = context.contract;
-//     let nft_contract = context.nft_contract;
-//     let worker = context.worker;
-//     let token_id = "test";
-//     let latest_block = worker.view_block().await?;
-//     let expiration_ts_nano = latest_block.timestamp() + ONE_BLOCK_IN_NANO * 10;
+    let contract = context.contract;
+    let nft_contract = context.nft_contract;
+    let worker = context.worker;
+    let token_id = "test";
+    let latest_block = worker.view_block().await?;
+    let expiration_ts_nano = latest_block.timestamp() + ONE_BLOCK_IN_NANO * 10;
 
-//     println!("Creating lease ...");
-//     lender
-//         .call(nft_contract.id(), "nft_approve")
-//         .args_json(json!({
-//             "token_id": token_id,
-//             "account_id": contract.id(),
-//             "msg": json!({"contract_addr": nft_contract.id(),
-//                           "token_id": token_id,
-//                           "borrower_id": borrower.id(),
-//                           "expiration": expiration_ts_nano,
-//                           "price": "1"
-//             }).to_string()
-//         }))
-//         .deposit(parse_near!("1 N"))
-//         .transact()
-//         .await?
-//         .into_result()?;
-//     println!("      ✅ Lease created and pending on Bob's acceptence");
+    println!("Creating lease ...");
+    lender
+        .call(nft_contract.id(), "nft_approve")
+        .args_json(json!({
+            "token_id": token_id,
+            "account_id": contract.id(),
+            "msg": json!({"contract_addr": nft_contract.id(),
+                          "token_id": token_id,
+                          "borrower_id": borrower.id(),
+                          "expiration": expiration_ts_nano,
+                          "price": "1"
+            }).to_string()
+        }))
+        .deposit(parse_near!("1 N"))
+        .max_gas()
+        .transact()
+        .await?
+        .into_result()?;
+    println!("      ✅ Lease created and pending on Bob's acceptence");
 
-//     // lender Alice transfers the NFT to another user Charlse
-//     lender
-//         .call(nft_contract.id(), "nft_transfer")
-//         .args_json(json!({
-//             "receiver_id": new_owner.id(),
-//             "token_id": token_id,
-//             "approval_id": null,
-//             "memo": null,
-//         }))
-//         .deposit(1)
-//         .transact()
-//         .await?
-//         .into_result()?;
+    // lender Alice transfers the NFT to another user Charlse
+    lender
+        .call(nft_contract.id(), "nft_transfer")
+        .args_json(json!({
+            "receiver_id": new_owner.id(),
+            "token_id": token_id,
+            "approval_id": null,
+            "memo": null,
+        }))
+        .deposit(1)
+        .transact()
+        .await?
+        .into_result()?;
 
-//     // Verify the ownership of the token has been updated
-//     let token: Token = nft_contract
-//         .view("nft_token")
-//         .args_json(json!({
-//             "token_id": token_id,
-//         }))
-//         .await?
-//         .json()?;
-//     assert_eq!(token.owner_id.to_string(), new_owner.id().to_string());
-//     println!("       ✅ Lease token has been transferred from lender Alice to Charles");
+    // Verify the ownership of the token has been updated
+    let token: Token = nft_contract
+        .view("nft_token")
+        .args_json(json!({
+            "token_id": token_id,
+        }))
+        .await?
+        .json()?;
+    assert_eq!(token.owner_id.to_string(), new_owner.id().to_string());
+    println!("       ✅ Lease token has been transferred from lender Alice to Charles");
 
-//     // Confirming the created lease ...
-//     let leases: Vec<(String, LeaseCondition)> = contract
-//         .call("leases_by_owner")
-//         .args_json(json!({"account_id": lender.id()}))
-//         .transact()
-//         .await?
-//         .json()?;
+    // Confirming the created lease ...
+    let leases: Vec<(String, LeaseCondition)> = contract
+        .call("leases_by_owner")
+        .args_json(json!({"account_id": lender.id()}))
+        .transact()
+        .await?
+        .json()?;
 
-//     let lease_id = &leases[0].0;
-//     let result = borrower
-//         .call(contract.id(), "lending_accept")
-//         .args_json(json!({
-//             "lease_id": lease_id,
-//         }))
-//         .deposit(1)
-//         .max_gas()
-//         .transact()
-//         .await?
-//         .into_result();
-//     assert!(result.is_err());
-//     println!("       ✅ Lease cannot be accepted by Bob. The transaction will panic.");
+    let lease_id = &leases[0].0;
+    let result = borrower
+        .call(contract.id(), "lending_accept")
+        .args_json(json!({
+            "lease_id": lease_id,
+        }))
+        .deposit(1)
+        .max_gas()
+        .transact()
+        .await?
+        .into_result();
+    assert!(result.is_err());
+    println!("       ✅ Lease cannot be accepted by Bob. The transaction will panic.");
 
-//     let updated_leases: Vec<(String, LeaseCondition)> = contract
-//         .call("leases_by_owner")
-//         .args_json(json!({"account_id": lender.id()}))
-//         .transact()
-//         .await?
-//         .json()?;
-//     assert_eq!(updated_leases[0].1.state, LeaseState::Pending);
-//     println!("       ✅ Lease cannot be accepted by Bob, the state of the lease is still pending");
-//     Ok(())
-// }
+    let updated_leases: Vec<(String, LeaseCondition)> = contract
+        .call("leases_by_owner")
+        .args_json(json!({"account_id": lender.id()}))
+        .transact()
+        .await?
+        .json()?;
+    assert_eq!(updated_leases[0].1.state, LeaseState::Pending);
+    println!("       ✅ Lease cannot be accepted by Bob, the state of the lease is still pending");
+    Ok(())
+}
 
 // TODO: claim_back - NFT transfer check
 // TODO: claim_back - check lease amount recieval, probably by using ft_balance_of().


### PR DESCRIPTION
Use a cross contract call to fetch the payout info when creating the lease, i.e. when lender calls `nft_approve`
Set the payout info into the lease when initializing it instead of when transferring the token

Test plan:
integration test and unit test

