### PR TITLE
Reuse LeaseCondition in the integration test

### DIFF
--- a/contract/Cargo.lock
+++ b/contract/Cargo.lock
@@ -326,6 +326,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dyn-clone"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9b0705efd4599c15a38151f4721f7bc388306f61084d3bfd50bd07fbca5cb60"
+
+[[package]]
 name = "easy-ext"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -481,6 +487,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9b7d56ba4a8344d6be9729995e6b06f928af29998cdf79fe390cbf6b1fee838"
 
 [[package]]
+name = "lazy_static"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+dependencies = [
+ "spin",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.132"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -502,10 +517,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8452105ba047068f40ff7093dd1d9da90898e63dd61736462e9cdda6a90ad3c3"
 
 [[package]]
-name = "near-account-id"
-version = "0.13.0"
+name = "near-abi"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de83d74a9241be8cc4eb3055216966b58bf8c463e8e285c0dc553925acdd19fa"
+checksum = "885db39b08518fa700b73fa2214e8adbbfba316ba82dd510f50519173eadaf73"
+dependencies = [
+ "borsh",
+ "schemars",
+ "semver",
+ "serde",
+]
+
+[[package]]
+name = "near-account-id"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71d258582a1878e6db67400b0504a5099db85718d22c2e07f747fe1706ae7150"
 dependencies = [
  "borsh",
  "serde",
@@ -513,20 +540,21 @@ dependencies = [
 
 [[package]]
 name = "near-contract-standards"
-version = "4.0.0"
+version = "4.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6466c6aaad18800ff6a3cd104427dc8fd79e144714135224b8289b1dc43f7167"
+checksum = "7bacc932e79b26472797adfb21689294b6f90960d1570daaf1e0b682b59fcb35"
 dependencies = [
  "near-sdk",
+ "schemars",
  "serde",
  "serde_json",
 ]
 
 [[package]]
 name = "near-crypto"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8ecf0b8b31aa7f4e60f629f72213a2617ca4a5f45cd1ae9ed2cf7cecfebdbb7"
+checksum = "1e75673d69fd7365508f3d32483669fe45b03bfb34e4d9363e90adae9dfb416c"
 dependencies = [
  "arrayref",
  "blake2",
@@ -536,7 +564,6 @@ dependencies = [
  "curve25519-dalek",
  "derive_more",
  "ed25519-dalek",
- "libc",
  "near-account-id",
  "once_cell",
  "parity-secp256k1",
@@ -551,9 +578,9 @@ dependencies = [
 
 [[package]]
 name = "near-primitives"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a2ba19282e79a4485a77736b679d276b09870bbf8042a18e0f0ae36347489c5"
+checksum = "8ad1a9a1640539c81f065425c31bffcfbf6b31ef1aeaade59ce905f5df6ac860"
 dependencies = [
  "borsh",
  "byteorder",
@@ -580,9 +607,9 @@ dependencies = [
 
 [[package]]
 name = "near-primitives-core"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb561feb392bb8c4f540256073446e6689af087bf6356e8dddcf75fc279f201f"
+checksum = "91d508f0fc340f6461e4e256417685720d3c4c00bb5a939b105160e49137caba"
 dependencies = [
  "base64 0.11.0",
  "borsh",
@@ -597,9 +624,9 @@ dependencies = [
 
 [[package]]
 name = "near-rpc-error-core"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77fdd7ea8d8f786878651c37691515d5053f827ae60894aa40c16882b78f77c9"
+checksum = "93ee0b41c75ef859c193a8ff1dadfa0c8207bc0ac447cc22259721ad769a1408"
 dependencies = [
  "quote",
  "serde",
@@ -608,9 +635,9 @@ dependencies = [
 
 [[package]]
 name = "near-rpc-error-macro"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e521842b6ae864dfe5391afbbe2df9e9d8427c26e9333b2e0b65cd42094f7607"
+checksum = "8e837bd4bacd807073ec5ceb85708da7f721b46a4c2a978de86027fb0034ce31"
 dependencies = [
  "near-rpc-error-core",
  "serde",
@@ -619,19 +646,22 @@ dependencies = [
 
 [[package]]
 name = "near-sdk"
-version = "4.0.0"
+version = "4.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bda34e06e28fb9a09ac54efbdc49f0c9308780fc932aaa81c49c493fde974045"
+checksum = "15eb3de2defe3626260cc209a6cdb985c6b27b0bd4619fad97dcfae002c3c5bd"
 dependencies = [
  "base64 0.13.0",
  "borsh",
  "bs58",
+ "near-abi",
  "near-crypto",
  "near-primitives",
  "near-primitives-core",
  "near-sdk-macros",
  "near-sys",
  "near-vm-logic",
+ "once_cell",
+ "schemars",
  "serde",
  "serde_json",
  "wee_alloc",
@@ -639,9 +669,9 @@ dependencies = [
 
 [[package]]
 name = "near-sdk-macros"
-version = "4.0.0"
+version = "4.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72064fcc15a623a0d40a6c199ea5cbdc30a83cae4816889d46f218acf31bfba8"
+checksum = "4907affc9f5ed559456509188ff0024f1f2099c0830e6bdb66eb61d5b75912c0"
 dependencies = [
  "Inflector",
  "proc-macro2",
@@ -657,9 +687,9 @@ checksum = "e307313276eaeced2ca95740b5639e1f3125b7c97f0a1151809d105f1aa8c6d3"
 
 [[package]]
 name = "near-vm-errors"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e02faf2bc1f6ef82b965cfe44389808fb5594f7aca4b596766117f4ce74df20"
+checksum = "d0da466a30f0446639cbd788c30865086fac3e8dcb07a79e51d2b0775ed4261e"
 dependencies = [
  "borsh",
  "near-account-id",
@@ -669,9 +699,9 @@ dependencies = [
 
 [[package]]
 name = "near-vm-logic"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f024d90451cd3c24d7a0a5cabf3636b192a60eb8e3ff0456f6c18b91152c346d"
+checksum = "81b534828419bacbf1f7b11ef7b00420f248c548c485d3f0cfda8bb6931152f2"
 dependencies = [
  "base64 0.13.0",
  "borsh",
@@ -686,6 +716,7 @@ dependencies = [
  "serde",
  "sha2 0.10.5",
  "sha3",
+ "zeropool-bn",
 ]
 
 [[package]]
@@ -968,6 +999,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4501abdff3ae82a1c1b477a17252eb69cee9e66eb915c1abaa4f44d873df9f09"
 
 [[package]]
+name = "schemars"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a5fb6c61f29e723026dc8e923d94c694313212abbecbbe5f55a7748eec5b307"
+dependencies = [
+ "dyn-clone",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f188d036977451159430f3b8dc82ec76364a42b7e289c2b18a9a18f4470058e9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn",
+]
+
+[[package]]
 name = "semver"
 version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -987,6 +1042,17 @@ name = "serde_derive"
 version = "1.0.144"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94ed3a816fb1d101812f83e789f888322c34e291f894f19590dc310963e87a00"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85bf8229e7920a9f636479437026331ce11aa132b4dde37d121944a44d6e5f3c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1060,6 +1126,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "spin"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "static_assertions"
@@ -1331,4 +1403,18 @@ dependencies = [
  "quote",
  "syn",
  "synstructure",
+]
+
+[[package]]
+name = "zeropool-bn"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e61de68ede9ffdd69c01664f65a178c5188b73f78faa21f0936016a888ff7c"
+dependencies = [
+ "borsh",
+ "byteorder",
+ "crunchy",
+ "lazy_static",
+ "rand 0.8.5",
+ "rustc-hex",
 ]

--- a/contract/Cargo.toml
+++ b/contract/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-near-contract-standards = "4.0.0"
+near-contract-standards = "4.1.1"
 near-sdk = "4.0.0"
 # near-contract-standards = "4.0.0"
 uint = { version = "0.9.3", default-features = false }

--- a/contract/src/utils.rs
+++ b/contract/src/utils.rs
@@ -1,0 +1,7 @@
+use near_sdk::{env, AccountId, CryptoHash};
+
+pub fn hash_account_id(account_id: &AccountId) -> CryptoHash {
+    let mut hash = CryptoHash::default();
+    hash.copy_from_slice(&env::sha256(account_id.as_bytes()));
+    hash
+}

--- a/integration-tests/Cargo.lock
+++ b/integration-tests/Cargo.lock
@@ -1121,6 +1121,7 @@ dependencies = [
  "near-contract-standards",
  "near-sdk",
  "near-units",
+ "nft_rental",
  "pkg-config",
  "serde_json",
  "tokio",
@@ -1718,6 +1719,15 @@ dependencies = [
  "sha2 0.10.3",
  "sha3",
  "zeropool-bn",
+]
+
+[[package]]
+name = "nft_rental"
+version = "1.0.0"
+dependencies = [
+ "near-contract-standards",
+ "near-sdk",
+ "uint",
 ]
 
 [[package]]

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -13,6 +13,7 @@ anyhow = "1.0"
 borsh = "0.9"
 maplit = "1.0"
 near-units = "0.2.0"
+nft_rental = { path = "../contract"}
 # arbitrary_precision enabled for u128 types that workspaces requires for Balance types
 serde_json = { version = "1.0", features = ["arbitrary_precision"] }
 tokio = { version = "1.18.1", features = ["full"] }
@@ -20,5 +21,5 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3.11", features = ["env-filter"] }
 workspaces = "0.7.0"
 pkg-config = "0.3.1"
-near-contract-standards = "4.0.0"
+near-contract-standards = "4.1.1"
 near-sdk = "4.0.0"

--- a/integration-tests/tests/gas_usage.rs
+++ b/integration-tests/tests/gas_usage.rs
@@ -1,5 +1,5 @@
-use near_sdk::serde::{Deserialize, Serialize};
 use near_units::parse_near;
+use nft_rental::{LeaseCondition, LeaseState};
 use serde_json::json;
 use workspaces::{network::Sandbox, Account, Contract, Worker};
 
@@ -56,28 +56,6 @@ async fn init() -> anyhow::Result<Context> {
         nft_contract,
         worker,
     })
-}
-
-// TODO(libo): we can import them from the contract under testing.
-#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
-#[serde(crate = "near_sdk::serde")]
-enum LeaseState {
-    Pending,
-    Active,
-    Expired,
-}
-
-#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
-#[serde(crate = "near_sdk::serde")]
-struct LeaseCondition {
-    contract_addr: String, // NFT contract
-    token_id: String,      // NFT token
-    owner_id: String,      // Owner of the NFT
-    borrower: String,      // Borrower of the NFT
-    approval_id: u64,      // Approval from owner to lease
-    expiration: u64,       // TODO: duration
-    amount_near: u128,     // proposed lease cost
-    state: LeaseState,     // current lease state
 }
 
 async fn prepare_lease(context: &Context, token_id: String) -> anyhow::Result<()> {

--- a/integration-tests/tests/integration.rs
+++ b/integration-tests/tests/integration.rs
@@ -1,9 +1,7 @@
 use near_contract_standards::non_fungible_token::Token;
-use near_sdk::{
-    serde::{Deserialize, Serialize},
-    ONE_NEAR,
-};
+use near_sdk::ONE_NEAR;
 use near_units::parse_near;
+use nft_rental::{LeaseCondition, LeaseState};
 use serde_json::json;
 use workspaces::{network::Sandbox, Account, Contract, Worker};
 
@@ -28,8 +26,7 @@ const NFT_PAYOUT_CODE: &[u8] =
     include_bytes!("../target/wasm32-unknown-unknown/release/test_nft_with_payout.wasm");
 const NFT_NO_PAYOUT_CODE: &[u8] =
     include_bytes!("../target/wasm32-unknown-unknown/release/test_nft_without_payout.wasm");
-const FT_CODE: &[u8] =
-    include_bytes!("../target/wasm32-unknown-unknown/release/test_ft.wasm");
+const FT_CODE: &[u8] = include_bytes!("../target/wasm32-unknown-unknown/release/test_ft.wasm");
 
 async fn init(nft_code: &[u8]) -> anyhow::Result<Context> {
     let worker = workspaces::sandbox().await?;
@@ -84,28 +81,6 @@ async fn init(nft_code: &[u8]) -> anyhow::Result<Context> {
     })
 }
 
-// TODO(libo): we can import them from the contract under testing.
-#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
-#[serde(crate = "near_sdk::serde")]
-enum LeaseState {
-    Pending,
-    Active,
-    Expired,
-}
-
-#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
-#[serde(crate = "near_sdk::serde")]
-struct LeaseCondition {
-    contract_addr: String,
-    token_id: String,
-    lender_id: String,
-    borrower_id: String,
-    approval_id: u64,
-    expiration: u64,
-    price: u128,
-    state: LeaseState,
-}
-
 #[tokio::test]
 async fn test_claim_back_with_payout_success() -> anyhow::Result<()> {
     let context = init(NFT_PAYOUT_CODE).await?;
@@ -152,10 +127,10 @@ async fn test_claim_back_with_payout_success() -> anyhow::Result<()> {
 
     let lease = &leases[0].1;
 
-    assert_eq!(lease.contract_addr, nft_contract.id().to_string());
+    assert_to_string_eq!(lease.contract_addr, nft_contract.id());
     assert_eq!(lease.token_id, "test".to_string());
-    assert_eq!(lease.lender_id, lender.id().to_string());
-    assert_eq!(lease.borrower_id, borrower.id().to_string());
+    assert_to_string_eq!(lease.lender_id, lender.id().to_string());
+    assert_to_string_eq!(lease.borrower_id, borrower.id().to_string());
     assert_eq!(lease.expiration, expiration_ts_nano);
     assert_eq!(lease.price, price);
     assert_eq!(lease.state, LeaseState::Pending);

--- a/integration-tests/tests/utils.rs
+++ b/integration-tests/tests/utils.rs
@@ -2,3 +2,12 @@
 pub fn assert_aprox_eq(a: u128, b: u128) {
     assert!(a.abs_diff(b) < (a + b) / 200)
 }
+
+/// Assert the equality between to structs which support to be converted into string.
+/// It's useful for comparing the structs are hard to compare directly due to the type difference.
+#[macro_export]
+macro_rules! assert_to_string_eq {
+    ($left:expr, $right:expr) => {
+        assert_eq!($left.to_string(), $right.to_string());
+    };
+}


### PR DESCRIPTION
Also:

1. Upgrade to the newest version near_contracts_standard to avoid breakage. (`hash_account_id` is deprecated in the newest version. We have to implement it by ourselves.)
2. Add a macro to compare structs by converting them into string.