### PR TITLE
Handle Payout of the under-leased NFT When Using LEASE token

### DIFF
--- a/contract/src/nft/internal.rs
+++ b/contract/src/nft/internal.rs
@@ -43,7 +43,6 @@ impl Contract {
 
     /// Update NFT related fields. It will be called once lease become active.
     /// This function is visible only within the current contract
-    /// This function will also handle the payouts for the under-leased nft
     pub(crate) fn nft_mint(&mut self, lease_id: LeaseId, receiver_id: AccountId) {
         // Update the record for active_leases
         let mut active_lease_ids_set = self
@@ -66,20 +65,6 @@ impl Contract {
 
         // Record active leases/Lease Tokens
         self.active_lease_ids.insert(&lease_id);
-
-        // Handle payouts record for the under-leased nft
-        let mut lease_condition: LeaseCondition = self.lease_map.get(&lease_id).unwrap();
-        let proxy_payout = lease_condition.payout.unwrap_or_else(|| {
-            // if leased nft didn't provide payouts, we add a proxy payout record making original lender own all the rent.
-            // This will make claiming back using LEASE NFT easier.
-            Payout {
-                payout: HashMap::from([(
-                    lease_condition.lender_id,
-                    U128::from(lease_condition.price),
-                )]),
-            }
-        });
-        lease_condition.payout = Some(proxy_payout);
     }
 
     pub(crate) fn lease_token_id_to_lease_id(&self, token_id: &TokenId) -> LeaseId {

--- a/contract/src/nft/internal.rs
+++ b/contract/src/nft/internal.rs
@@ -43,6 +43,7 @@ impl Contract {
 
     /// Update NFT related fields. It will be called once lease become active.
     /// This function is visible only within the current contract
+    /// This function will also handle the payouts for the under-leased nft
     pub(crate) fn nft_mint(&mut self, lease_id: LeaseId, receiver_id: AccountId) {
         // Update the record for active_leases
         let mut active_lease_ids_set = self
@@ -65,6 +66,20 @@ impl Contract {
 
         // Record active leases/Lease Tokens
         self.active_lease_ids.insert(&lease_id);
+
+        // Handle payouts record for the under-leased nft
+        let mut lease_condition: LeaseCondition = self.lease_map.get(&lease_id).unwrap();
+        let proxy_payout = lease_condition.payout.unwrap_or_else(|| {
+            // if leased nft didn't provide payouts, we add a proxy payout record making original lender own all the rent.
+            // This will make claiming back using LEASE NFT easier.
+            Payout {
+                payout: HashMap::from([(
+                    lease_condition.lender_id,
+                    U128::from(lease_condition.price),
+                )]),
+            }
+        });
+        lease_condition.payout = Some(proxy_payout);
     }
 
     pub(crate) fn lease_token_id_to_lease_id(&self, token_id: &TokenId) -> LeaseId {


### PR DESCRIPTION
[NR-109](https://linear.app/niftyrent/issue/NR-109/bug-fix-correctly-handle-payout-cases)

At claim back, we transfer NFT to the LEASE token owner and send the rent to the original lender (or payouts account if there is any). 

To support sending rent correctly with payouts, at LEASE nft minting (lease activate) stage, we automatically create a payout record internally, if the field is not provided at lease creation. This proxy payout record marks the original lender as the only account to receive all the rent.