### PR TITLE
Use U128 for the price field in LeaseCondition.

### DIFF
--- a/contract/src/externals.rs
+++ b/contract/src/externals.rs
@@ -1,6 +1,7 @@
 use crate::*;
 
 /// Interface of this contract
+// TODO(libo): explicitly implement this trait.
 #[ext_contract(ext_self)]
 trait ExtSelf {
     fn activate_lease(&mut self, lease_id: LeaseId) -> PromiseOrValue<U128>;
@@ -13,7 +14,7 @@ trait ExtSelf {
         borrower_id: AccountId,
         ft_contract_addr: AccountId,
         expiration: u64,
-        price: u128,
+        price: U128,
         approval_id: u64,
     ) -> Promise;
 }

--- a/integration-tests/tests/integration.rs
+++ b/integration-tests/tests/integration.rs
@@ -166,7 +166,7 @@ async fn test_claim_back_with_payout_success() -> anyhow::Result<()> {
     assert_to_string_eq!(lease.lender_id, lender.id().to_string());
     assert_to_string_eq!(lease.borrower_id, borrower.id().to_string());
     assert_eq!(lease.expiration, expiration_ts_nano);
-    assert_eq!(lease.price, price);
+    assert_eq!(lease.price.0, price);
     assert_eq!(lease.state, LeaseState::Pending);
     println!("      ✅ Lease creation confirmed");
 


### PR DESCRIPTION
Passing u128 to the frontend causes the floating point number precision problem. Using U128 will fix it.

In general, U128 is a more friendly type for input and output. The only drawback is that it take a little more storage space. We can optimise it in the future if needed.