### PR TITLE
Bug Fix: add near_bindgen for nft methods

### DIFF
--- a/contract/src/nft/core.rs
+++ b/contract/src/nft/core.rs
@@ -35,6 +35,7 @@ trait NonFungibleTokenResolver {
     ) -> bool;
 }
 
+#[near_bindgen]
 impl NonFungibleTokenCore for Contract {
     fn nft_transfer(
         &mut self,
@@ -137,6 +138,7 @@ impl NonFungibleTokenCore for Contract {
     }
 }
 
+#[near_bindgen]
 impl NonFungibleTokenResolver for Contract {
     /// Resolves XCC result from receiver's nft_on_transfer
     /// Returns true if the token was successfully transferred to the receiver_id

--- a/contract/src/nft/enumeration.rs
+++ b/contract/src/nft/enumeration.rs
@@ -4,6 +4,7 @@ use near_contract_standards::non_fungible_token::{
 };
 use near_sdk::json_types::U128;
 
+#[near_bindgen]
 impl NonFungibleTokenEnumeration for Contract {
     /// Returns the total supply of non-fungible tokens as a string representing an
     /// Unsigned 128-bit integer to avoid JSON number limit of 2^53.


### PR DESCRIPTION
The near_bindgen marco is missed for some methods in NFT implementation, causing the methods not exposed on chain.
This PR fixes it.