### PR TITLE
Add Support for Events Standard

### DIFF
--- a/contract/src/lib.rs
+++ b/contract/src/lib.rs
@@ -1741,7 +1741,7 @@ mod tests {
     }
 
     // helper method to generate a dummy AccountId using input name
-    pub(crate) fn get_dummy_account_id(account_name: &str) -> AccountId {
+    pub(crate) fn create_a_dummy_account_id(account_name: &str) -> AccountId {
         AccountId::new_unchecked(account_name.to_string())
     }
 

--- a/contract/src/lib.rs
+++ b/contract/src/lib.rs
@@ -508,7 +508,7 @@ impl Contract {
         // update active leases set
         self.active_lease_ids.remove(&lease_id);
 
-        // update active_lease_ids_per_owner
+        // update active_lease_ids_by_lender
         let mut active_lease_id_set = self
             .active_lease_ids_by_lender
             .get(&lease_condition.lender_id);

--- a/contract/src/lib.rs
+++ b/contract/src/lib.rs
@@ -1740,6 +1740,11 @@ mod tests {
         )
     }
 
+    // helper method to generate a dummy AccountId using input name
+    pub(crate) fn get_dummy_account_id(account_name: &str) -> AccountId {
+        AccountId::new_unchecked(account_name.to_string())
+    }
+
     // Helper function create a lease condition based on input
     fn create_lease_condition(
         contract_addr: AccountId,

--- a/contract/src/nft/core.rs
+++ b/contract/src/nft/core.rs
@@ -34,7 +34,7 @@ trait NonFungibleTokenResolver {
         owner_id: AccountId,
         receiver_id: AccountId,
         token_id: TokenId,
-        authorized_id: Option<AccountId>,  // logging trasnfer event - deault to None
+        approved_account_ids: Option<HashMap<AccountId, u64>>,  // logging trasnfer event - deault to None
         memo: Option<String>,   // memo for logging transfer event
     ) -> bool;
 }
@@ -79,7 +79,7 @@ impl NonFungibleTokenCore for Contract {
             &sender_id,
             &receiver_id,
             &token_id,
-            memo,
+            memo.clone(),
         );
 
         ext_nft_receiver::ext(receiver_id.clone())
@@ -93,7 +93,7 @@ impl NonFungibleTokenCore for Contract {
             .then(
                 ext_self::ext(env::current_account_id())
                     .with_static_gas(GAS_FOR_RESOLVE_TRANSFER)
-                    .nft_resolve_transfer(previous_token.owner_id, receiver_id, token_id, None, None),
+                    .nft_resolve_transfer(previous_token.owner_id, receiver_id, token_id, None, memo),
             )
             .into()
     }
@@ -155,8 +155,7 @@ impl NonFungibleTokenResolver for Contract {
         token_id: TokenId,
         // TODO: remove this suppressor after implementing approval.
         #[allow(unused_variables)]
-        authorized_id: Option<AccountId>,  // logging trasnfer event - deault to None
-        #[allow(unused_variables)]
+        approved_account_ids: Option<HashMap<AccountId, u64>>,  // logging trasnfer event - deault to None
         memo: Option<String>,   // memo for logging transfer event
     ) -> bool {
         // Check whether the token should be returned to previous owner
@@ -197,7 +196,7 @@ impl NonFungibleTokenResolver for Contract {
             new_owner_id: &previouse_owner_id,
             token_ids: &[&token_id],
             authorized_id: None,
-            memo: None,
+            memo: memo.as_deref(),
         }
         .emit();
 

--- a/contract/src/nft/core.rs
+++ b/contract/src/nft/core.rs
@@ -221,7 +221,7 @@ mod tests{
     use near_contract_standards::non_fungible_token::TokenId;
     use near_contract_standards::non_fungible_token::core::NonFungibleTokenCore;
 
-    use near_sdk::test_utils::{self, accounts,VMContextBuilder};
+    use near_sdk::test_utils::{self, accounts, VMContextBuilder};
     use near_sdk::testing_env;
 
     #[test]

--- a/contract/src/nft/internal.rs
+++ b/contract/src/nft/internal.rs
@@ -104,7 +104,7 @@ mod tests {
     use crate::tests::*;
     use crate::{Contract, LeaseId, LeaseState};
 
-    use near_contract_standards::non_fungible_token::{events::NftMint, TokenId};
+    use near_contract_standards::non_fungible_token::TokenId;
     use near_sdk::test_utils::{self, accounts};
     use near_sdk::AccountId;
 

--- a/contract/src/nft/internal.rs
+++ b/contract/src/nft/internal.rs
@@ -176,7 +176,7 @@ mod tests {
     fn test_event_mint_log_succeeds() {
         let mut contract = Contract::new(accounts(0).into());
         let mut lease_condition = create_lease_condition_default();
-        lease_condition.lender_id = get_dummy_account_id("alice");
+        lease_condition.lender_id = create_a_dummy_account_id("alice");
 
         let lease_key = "test_key".to_string();
         contract.internal_insert_lease(&lease_key, &lease_condition);
@@ -188,30 +188,5 @@ mod tests {
         let mint_log = &test_utils::get_logs()[0];
         let mint_log_expected = r#"EVENT_JSON:{"standard":"nep171","version":"1.0.0","event":"nft_mint","data":[{"owner_id":"alice","token_ids":["test_key_lender"]}]}"#;
         assert_eq!(mint_log, mint_log_expected);
-    }
-
-    #[test]
-    fn test_event_transfer_log_for_nft_transfer_succeeds() {
-        let mut contract = Contract::new(accounts(0).into());
-        let mut lease_condition = create_lease_condition_default();
-        lease_condition.lender_id = get_dummy_account_id("alice");
-
-        let lease_key = "test_key".to_string();
-        contract.internal_insert_lease(&lease_key, &lease_condition);
-        lease_condition.state = LeaseState::Active;
-
-        let token_id = contract.lease_id_to_lease_token_id(&lease_key);
-        contract.nft_mint(lease_key.clone(), lease_condition.lender_id.clone());
-        contract.internal_transfer(
-            &lease_condition.lender_id,
-            &get_dummy_account_id("bob"),
-            &token_id,
-            None,
-        );
-        
-        // Check logs emit correctly
-        let transfer_log = &test_utils::get_logs()[1];
-        let transfer_log_expected = r#"EVENT_JSON:{"standard":"nep171","version":"1.0.0","event":"nft_transfer","data":[{"old_owner_id":"alice","new_owner_id":"bob","token_ids":["test_key_lender"]}]}"#;
-        assert_eq!(transfer_log, transfer_log_expected);
     }
 }

--- a/contract/src/nft/internal.rs
+++ b/contract/src/nft/internal.rs
@@ -34,7 +34,7 @@ impl Contract {
             old_owner_id: sender_id,
             new_owner_id: receiver_id,
             token_ids: &[token_id],
-            authorized_id: None, // approval is not supported at the moment
+            authorized_id: None,
             memo: memo.as_deref(),
         }
         .emit();
@@ -175,14 +175,9 @@ mod tests {
     #[test]
     fn test_event_mint_log_succeeds() {
         let mut contract = Contract::new(accounts(0).into());
-        let mut lease_condition = create_lease_condition_default();
-        lease_condition.lender_id = create_a_dummy_account_id("alice");
-
         let lease_key = "test_key".to_string();
-        contract.internal_insert_lease(&lease_key, &lease_condition);
-        lease_condition.state = LeaseState::Active;
 
-        contract.nft_mint(lease_key.clone(), lease_condition.lender_id.clone());
+        contract.nft_mint(lease_key.clone(), create_a_dummy_account_id("alice"));
 
         // Check logs output correctly
         let mint_log = &test_utils::get_logs()[0];


### PR DESCRIPTION
[NR-105](https://linear.app/niftyrent/issue/NR-105/add-support-for-events)

Emit event logs at the following places, as per the [Events](https://nomicon.io/Standards/Tokens/NonFungibleToken/Event) standard:
- at nft mint (or lease activation)
- at nft transfer
- at nft resolve transfer, when a transfer should be reverted

The implementation utilises near sdk's events type

MISC:
- 2 more unit tests added to check the event log output.
- a helper function added to generate easy to read dummy account id at testing

