### PR TITLE
Fix LEASE NFT token Title & Update Test plan readme

### DIFF
--- a/contract/src/nft/core.rs
+++ b/contract/src/nft/core.rs
@@ -110,7 +110,7 @@ impl NonFungibleTokenCore for Contract {
 
             // Generate token metadata on the fly. Hard coded for now
             let token_metadata = TokenMetadata{
-                title: Some(format!("NiftyRent Lease Ownership Token: {}", &token_id)), 
+                title: Some(format!("NiFTyRent Lease Ownership Token: {}", &token_id)), 
                 description: Some(
                     format!("
                     This is a token representing the ownership the NFT under the NiFTyRent lease: {lease_id}\n

--- a/integration-tests/README.md
+++ b/integration-tests/README.md
@@ -24,4 +24,10 @@ Integration test are based in a different directory ./integration-tests
 - `test_accept_leases_already_lent`: This test verifies that the call will pass for the first time when lender accepts the lease but should faile if borrowers accepts the same lease for multiple times.
 - `test_accept_lease_fails_already_transferred`: This test verifies that the call should fail if the token has been transferred before the borrowers accepts the lease.
 
+The following integration tests have been added for Lease Ownership NFT
+- `test_lender_receives_a_lease_nft_after_lease_activation`: lender can receive a lease nft token with correct token information after the leaes got activated.
+- `test_lease_nft_can_be_transferred_to_other_account`: owner of the lease nft token can transfer the token to other account. The underlying lease's lender info will also be udpated correctly.
+- `test_claim_back_without_payout_using_lease_nft`: owner of the lease nft token can claim back the renting nft successfully & rent should be paid in full to original lender.
+- `test_claim_back_with_payout_using_lease_nft`: owner of the lease nft token can claim back the renting nft successfully & rent should be paid correctly to all payout accounds.
+
 Inline comment and test output have also been added. Please refer the code.

--- a/integration-tests/tests/integration.rs
+++ b/integration-tests/tests/integration.rs
@@ -758,7 +758,7 @@ async fn test_lender_receives_a_lease_nft_after_lease_activation() -> anyhow::Re
     assert!(token_metadata.is_some());
     assert_to_string_eq!(
         format!(
-            "NiftyRent Lease Ownership Token: {}",
+            "NiFTyRent Lease Ownership Token: {}",
             &lease_token_id_expected
         ),
         token_metadata.unwrap().title.as_ref().unwrap()


### PR DESCRIPTION
- Adjust title to use the correct format. Currently, the title looks like following, "NiftyRent".
- Updated test plan in readme.

<img width="975" alt="Ownership_NFT_for_lender" src="https://user-images.githubusercontent.com/5934114/221441420-bfe90f3e-19bd-4d37-8666-fa8564584bb6.png">
