### PR TITLE
Remove listing after it has been activated & Rename some variables

### DIFF
--- a/contract/src/lib.rs
+++ b/contract/src/lib.rs
@@ -63,9 +63,9 @@ pub struct LeaseJson {
     token_id: TokenId,
     borrower_id: AccountId,
     ft_contract_addr: AccountId,
+    price: U128,
     start_ts_nano: u64,
     end_ts_nano: u64,
-    price: U128,
 }
 
 // TODO(syu): update LeaseJson to LeaseJsonV2
@@ -717,7 +717,7 @@ impl Contract {
         self.lease_map.insert(&lease_id, &lease_condition); // insert data back to persis the value
     }
 }
-
+// TODO(syu): nft_on_approve is no longer needed after introduing marketplace. Remove it.
 // TODO: move nft callback function to separate file e.g. nft_callbacks.rs
 /**
     trait that will be used as the callback from the NFT contract. When nft_approve is

--- a/marketplace/src/externals.rs
+++ b/marketplace/src/externals.rs
@@ -17,12 +17,7 @@ pub trait NonFungibleToken {
 /// FT contract interface for XCC
 #[ext_contract(ext_ft)]
 pub trait FungibleToken {
-    fn ft_transfer(
-        &mut self,
-        receiver_id: AccountId,
-        amount: U128,
-        memo: Option<String>,
-    );
+    fn ft_transfer(&mut self, receiver_id: AccountId, amount: U128, memo: Option<String>);
 }
 
 /// Interface of this marketplace contract, for XCC by the contract itself.
@@ -33,5 +28,6 @@ trait ExtSelf {
         ft_contract_id: AccountId,
         amount: U128,
         memo: Option<String>,
+        listing_id: ListingId,
     ) -> PromiseOrValue<U128>;
 }

--- a/marketplace/src/ft_callbacks.rs
+++ b/marketplace/src/ft_callbacks.rs
@@ -51,7 +51,7 @@ impl FungibleTokenReceiver for Contract {
             near_sdk::serde_json::from_str(&msg).expect("Invalid lease listing");
 
         let listing: Listing = self
-            .listings
+            .listing_map
             .get(&listing_acceptance_json.listing_id)
             .unwrap();
 
@@ -81,9 +81,9 @@ impl FungibleTokenReceiver for Contract {
             "borrower_id": sender_id.clone(),
             "approval_id": listing.approval_id.clone(),
             "ft_contract_addr": listing.ft_contract_id.clone(),
+            "price": listing.price.clone(),
             "start_ts_nano": listing.lease_start_ts_nano.clone(),
             "end_ts_nano": listing.lease_end_ts_nano.clone(),
-            "price": listing.price.clone(),
         })
         .to_string();
 
@@ -107,6 +107,7 @@ impl FungibleTokenReceiver for Contract {
                         listing.ft_contract_id.clone(), // ft_contract_id
                         listing.price.clone(),          // amount
                         None,                           // memo
+                        listing_acceptance_json.listing_id,
                     ),
             )
             .as_return()

--- a/marketplace/src/ft_callbacks.rs
+++ b/marketplace/src/ft_callbacks.rs
@@ -51,7 +51,7 @@ impl FungibleTokenReceiver for Contract {
             near_sdk::serde_json::from_str(&msg).expect("Invalid lease listing");
 
         let listing: Listing = self
-            .listing_map
+            .listing_by_id
             .get(&listing_acceptance_json.listing_id)
             .unwrap();
 

--- a/marketplace/src/ft_callbacks.rs
+++ b/marketplace/src/ft_callbacks.rs
@@ -95,11 +95,12 @@ impl FungibleTokenReceiver for Contract {
                 self.rental_contract_id.clone(),   // receiver_id
                 listing.nft_token_id.clone(),      // token_id
                 msg_lease_json,                    // msg
-                Some(listing.approval_id.clone()), //approval_id
+                Some(listing.approval_id.clone()), // approval_id
                 None,                              // memo
             )
             .then(
                 // Trasnfer the rent to Core contract, after resolving the returned promise
+                // listing will also be removed when both transfers succeeded
                 ext_self::ext(env::current_account_id())
                     .with_static_gas(Gas(10 * TGAS))
                     .with_attached_deposit(1)
@@ -113,6 +114,5 @@ impl FungibleTokenReceiver for Contract {
             .as_return()
             .into()
 
-        // TODO(syu): remove the listing after both steps succeed
     }
 }

--- a/marketplace/src/lib.rs
+++ b/marketplace/src/lib.rs
@@ -253,7 +253,7 @@ impl Contract {
             .get(&listing_id)
             .expect("Input listing_id does not exist");
 
-        // remove the record in listings_by_id index
+        // remove the record in listing_by_id index
         self.listing_by_id.remove(&listing_id);
 
         // remove from index: listing_ids_by_owner_id

--- a/marketplace/src/lib.rs
+++ b/marketplace/src/lib.rs
@@ -45,7 +45,7 @@ pub struct Contract {
     pub treasury_id: AccountId,
     /// The rental proxy contract (i.e. the core contract) id this marketplace use.
     pub rental_contract_id: AccountId,
-    pub listing_map: UnorderedMap<ListingId, Listing>,
+    pub listing_by_id: UnorderedMap<ListingId, Listing>,
     /// Whitelist of FT contracts for rent payment.
     pub allowed_ft_contract_ids: UnorderedSet<AccountId>,
     // TODO(libo): Shops?
@@ -76,7 +76,7 @@ impl Contract {
             owner_id: owner_id.into(),
             treasury_id: treasury_id.into(),
             rental_contract_id,
-            listing_map: UnorderedMap::new(StorageKey::Listings),
+            listing_by_id: UnorderedMap::new(StorageKey::Listings),
             allowed_ft_contract_ids: UnorderedSet::new(StorageKey::FTTokenIds),
             allowed_nft_contract_ids: UnorderedSet::new(StorageKey::NFTContractIds),
             listing_ids_by_owner_id: LookupMap::new(StorageKey::ListingsByOwnerId),
@@ -188,7 +188,7 @@ impl Contract {
             .with_alphabet(bs58::Alphabet::BITCOIN)
             .into_string();
 
-        self.listing_map.insert(
+        self.listing_by_id.insert(
             &listing_id,
             &Listing {
                 owner_id: owner_id.clone(),
@@ -249,12 +249,12 @@ impl Contract {
     fn internal_remove_listing(&mut self, listing_id: ListingId) {
         // check if the target listing exist
         let listing = self
-            .listing_map
+            .listing_by_id
             .get(&listing_id)
             .expect("Input listing_id does not exist");
 
-        // remove listing map record
-        self.listing_map.remove(&listing_id);
+        // remove the record in listings_by_id index
+        self.listing_by_id.remove(&listing_id);
 
         // remove from index: listing_ids_by_owner_id
         let mut listing_id_set = self.listing_ids_by_owner_id.get(&listing.owner_id).unwrap();

--- a/marketplace/src/lib.rs
+++ b/marketplace/src/lib.rs
@@ -286,7 +286,16 @@ impl Contract {
         env::log_str(
             &json!({
                 "type": "remove_listing",
-                "listing_id": listing_id,
+                "params": {
+                    "owner_id": listing.owner_id,
+                    "approval_id": listing.approval_id,
+                    "nft_contract_id": listing.nft_contract_id,
+                    "nft_token_id": listing.nft_token_id,
+                    "ft_contract_id": listing.ft_contract_id,
+                    "price": listing.price,
+                    "lease_start_ts_nano": listing.lease_start_ts_nano,
+                    "lease_end_ts_nano": listing.lease_end_ts_nano,
+                }
             })
             .to_string(),
         );

--- a/marketplace/src/lib.rs
+++ b/marketplace/src/lib.rs
@@ -45,16 +45,15 @@ pub struct Contract {
     pub treasury_id: AccountId,
     /// The rental proxy contract (i.e. the core contract) id this marketplace use.
     pub rental_contract_id: AccountId,
-    pub listings: UnorderedMap<ListingId, Listing>,
+    pub listing_map: UnorderedMap<ListingId, Listing>,
     /// Whitelist of FT contracts for rent payment.
     pub allowed_ft_contract_ids: UnorderedSet<AccountId>,
     // TODO(libo): Shops?
     pub allowed_nft_contract_ids: UnorderedSet<AccountId>,
 
-    // TODO: do we need it?
     /// Indices of listing for quick lookup.
-    pub listings_by_owner_id: LookupMap<AccountId, UnorderedSet<ListingId>>,
-    pub listings_by_nft_contract_id: LookupMap<AccountId, UnorderedSet<ListingId>>,
+    pub listing_ids_by_owner_id: LookupMap<AccountId, UnorderedSet<ListingId>>,
+    pub listing_ids_by_nft_contract_id: LookupMap<AccountId, UnorderedSet<ListingId>>,
 }
 
 #[derive(BorshStorageKey, BorshSerialize)]
@@ -77,11 +76,11 @@ impl Contract {
             owner_id: owner_id.into(),
             treasury_id: treasury_id.into(),
             rental_contract_id,
-            listings: UnorderedMap::new(StorageKey::Listings),
+            listing_map: UnorderedMap::new(StorageKey::Listings),
             allowed_ft_contract_ids: UnorderedSet::new(StorageKey::FTTokenIds),
             allowed_nft_contract_ids: UnorderedSet::new(StorageKey::NFTContractIds),
-            listings_by_owner_id: LookupMap::new(StorageKey::ListingsByOwnerId),
-            listings_by_nft_contract_id: LookupMap::new(StorageKey::ListingsByNftContractId),
+            listing_ids_by_owner_id: LookupMap::new(StorageKey::ListingsByOwnerId),
+            listing_ids_by_nft_contract_id: LookupMap::new(StorageKey::ListingsByNftContractId),
         }
     }
 
@@ -144,6 +143,7 @@ impl Contract {
         ft_contract_id: AccountId,
         amount: U128,
         memo: Option<String>,
+        listing_id: ListingId,
     ) -> U128 {
         require!(
             is_promise_success(),
@@ -160,6 +160,9 @@ impl Contract {
                 amount,                          // amount
                 memo,                            // memo
             );
+
+        // remove the listing when both nft transfer and rent transfer succeeded
+        self.internal_remove_listing(listing_id.clone());
 
         // refund set to 0
         let refund_ammount: U128 = U128::from(0);
@@ -185,7 +188,7 @@ impl Contract {
             .with_alphabet(bs58::Alphabet::BITCOIN)
             .into_string();
 
-        self.listings.insert(
+        self.listing_map.insert(
             &listing_id,
             &Listing {
                 owner_id: owner_id.clone(),
@@ -199,19 +202,22 @@ impl Contract {
             },
         );
 
-        // Update the listings by owner id index
-        let mut listing_ids_set = self.listings_by_owner_id.get(&owner_id).unwrap_or_else(|| {
-            UnorderedSet::new(StorageKey::ListingsByOwnerIdInner {
-                account_id_hash: hash_account_id(&owner_id),
-            })
-        });
+        // Update the index: listing_ids_by_owner_id
+        let mut listing_ids_set =
+            self.listing_ids_by_owner_id
+                .get(&owner_id)
+                .unwrap_or_else(|| {
+                    UnorderedSet::new(StorageKey::ListingsByOwnerIdInner {
+                        account_id_hash: hash_account_id(&owner_id),
+                    })
+                });
         listing_ids_set.insert(&listing_id);
-        self.listings_by_owner_id
+        self.listing_ids_by_owner_id
             .insert(&owner_id, &listing_ids_set);
 
-        // Update the listings by NFT contract id index
+        // Update the index: listing_ids_by_NFT_contract_id
         let mut listing_ids_set = self
-            .listings_by_nft_contract_id
+            .listing_ids_by_nft_contract_id
             .get(&nft_contract_id)
             .unwrap_or_else(|| {
                 UnorderedSet::new(StorageKey::ListingsByNftContractIdInner {
@@ -219,7 +225,7 @@ impl Contract {
                 })
             });
         listing_ids_set.insert(&listing_id);
-        self.listings_by_nft_contract_id
+        self.listing_ids_by_nft_contract_id
             .insert(&nft_contract_id, &listing_ids_set);
 
         env::log_str(
@@ -241,7 +247,49 @@ impl Contract {
     }
 
     fn internal_remove_listing(&mut self, listing_id: ListingId) {
-        todo!()
+        // check if the target listing exist
+        let listing = self
+            .listing_map
+            .get(&listing_id)
+            .expect("Input listing_id does not exist");
+
+        // remove listing map record
+        self.listing_map.remove(&listing_id);
+
+        // remove from index: listing_ids_by_owner_id
+        let mut listing_id_set = self.listing_ids_by_owner_id.get(&listing.owner_id).unwrap();
+        listing_id_set.remove(&listing_id);
+
+        if listing_id_set.is_empty() {
+            self.listing_ids_by_owner_id.remove(&listing.owner_id);
+        } else {
+            self.listing_ids_by_owner_id
+                .insert(&listing.owner_id, &listing_id_set);
+        }
+
+        // remove from index: listing_ids_by_NFT_contract_id
+        let mut listing_id_set = self
+            .listing_ids_by_nft_contract_id
+            .get(&listing.nft_contract_id)
+            .unwrap();
+        listing_id_set.remove(&listing_id);
+
+        if listing_id_set.is_empty() {
+            self.listing_ids_by_nft_contract_id
+                .remove(&listing.nft_contract_id);
+        } else {
+            self.listing_ids_by_owner_id
+                .insert(&listing.nft_contract_id, &listing_id_set);
+        }
+
+        // log the listing removal
+        env::log_str(
+            &json!({
+                "type": "remove_listing",
+                "listing_id": listing_id,
+            })
+            .to_string(),
+        );
     }
 
     fn assert_owner(&self) {


### PR DESCRIPTION
- Remove listing from marketplace record when both nft transfer and rent transfer succeeded
- Rename some variables to be more accurate.

P.S.
I am not quite fond of the design to put listing removal in the same XCC function for transferring rent. It does the work for now. I will think about other options to do the listing removal without introducing extra XCC.